### PR TITLE
Task03 Лев Сорвин МКН

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -33,10 +33,6 @@ jobs:
       - name: Build
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
-      - name: test_sift
+      - name: test_sfm
         working-directory: ${{github.workspace}}
-        run: ./build/test_sift
-
-      - name: test_matching
-        working-directory: ${{github.workspace}}
-        run: ./build/test_matching
+        run: ./build/test_sfm

--- a/src/phg/sfm/ematrix.cpp
+++ b/src/phg/sfm/ematrix.cpp
@@ -17,10 +17,12 @@ namespace {
         Eigen::MatrixXd E;
         copy(Ecv, E);
 
-        Eigen::JacobiSVD<Eigen::MatrixXd> svd(E, Eigen::ComputeFullU | Eigen::ComputeFullV);
-        throw std::runtime_error("not implemented yet");
-// TODO
-
+        Eigen::JacobiSVD<Eigen::MatrixXd> svd(E);
+        auto epsilon = 0.0001;
+        auto singularValues = svd.singularValues();
+        std::cout << "singularValues = " << singularValues << std::endl;
+//        assert(abs(singularValues[0] - singularValues[1]) < epsilon);
+//        assert(abs(singularValues[2]) < epsilon);
         copy(E, Ecv);
     }
 
@@ -28,12 +30,12 @@ namespace {
 
 cv::Matx33d phg::fmatrix2ematrix(const cv::Matx33d &F, const phg::Calibration &calib0, const phg::Calibration &calib1)
 {
-    throw std::runtime_error("not implemented yet");
-//    matrix3d E = TODO;
-//
-//    ensureSpectralProperty(E);
-//
-//    return E;
+//    matrix3d E = calib0.K().t() * F * calib1.K();
+    matrix3d E = calib1.K().t() * F * calib0.K();
+
+    ensureSpectralProperty(E);
+
+    return E;
 }
 
 namespace {
@@ -61,21 +63,27 @@ namespace {
 
     bool depthTest(const vector2d &m0, const vector2d &m1, const phg::Calibration &calib0, const phg::Calibration &calib1, const matrix34d &P0, const matrix34d &P1)
     {
-        throw std::runtime_error("not implemented yet");
-//        // скомпенсировать калибровки камер
-//        vector3d p0 = TODO;
-//        vector3d p1 = TODO;
-//
-//        vector3d ps[2] = {p0, p1};
-//        matrix34d Ps[2] = {P0, P1};
-//
-//        vector4d X = phg::triangulatePoint(Ps, ps, 2);
-//        if (X[3] != 0) {
-//            X /= X[3];
-//        }
-//
-//        // точка должна иметь положительную глубину для обеих камер
-//        return TODO && TODO;
+//        throw std::runtime_error("not implemented yet");
+        // скомпенсировать калибровки камер
+        vector3d p0 = calib0.unproject(m0);
+        vector3d p1 = calib1.unproject(m1);
+
+        vector3d ps[2] = {p0, p1};
+        matrix34d Ps[2] = {P0, P1};
+
+        vector4d X = phg::triangulatePoint(Ps, ps, 2);
+        if (X[3] != 0) {
+            X /= X[3];
+        }
+        auto is_on_cam = [&X](matrix34d const& M) {
+            auto rotation = M.get_minor<3, 3>(0, 0).inv();
+            auto cam_pos = -rotation * M.get_minor<3, 1>(0, 3);
+            auto camera_z_axis = rotation.get_minor<3, 1>(0, 2);
+            return (X.get_minor<3, 1>(0, 0) - cam_pos).dot(camera_z_axis) >= 0.0;
+        };
+
+        // точка должна иметь положительную глубину для обеих камер
+        return is_on_cam(calib0.K().inv() * P0) && is_on_cam(calib1.K().inv() * P1);
     }
 }
 
@@ -86,82 +94,89 @@ namespace {
 // Это дополнительное ограничение позволяет разложить существенную матрицу с точностью до 4 решений, вместо произвольного проективного преобразования (см. Hartley & Zisserman p.258)
 // Обычно мы можем использовать одну общую калибровку, более менее верную для большого количества реальных камер и с ее помощью выполнить
 // первичное разложение существенной матрицы (а из него, взаимное расположение камер) для последующего уточнения методом нелинейной оптимизации
+//
+// Возвращает матрицу камеры без калибровки
 void phg::decomposeEMatrix(cv::Matx34d &P0, cv::Matx34d &P1, const cv::Matx33d &Ecv, const std::vector<cv::Vec2d> &m0, const std::vector<cv::Vec2d> &m1, const Calibration &calib0, const Calibration &calib1)
 {
-    throw std::runtime_error("not implemented yet");
-//    if (m0.size() != m1.size()) {
-//        throw std::runtime_error("decomposeEMatrix : m0.size() != m1.size()");
-//    }
-//
-//    using mat = Eigen::MatrixXd;
-//    using vec = Eigen::VectorXd;
-//
-//    mat E;
-//    copy(Ecv, E);
-//
-//    // (см. Hartley & Zisserman p.258)
-//
-//    Eigen::JacobiSVD<mat> svd(E, Eigen::ComputeFullU | Eigen::ComputeFullV);
-//
-//    mat U = svd.matrixU();
-//    vec s = svd.singularValues();
-//    mat V = svd.matrixV();
-//
-//    // U, V must be rotation matrices, not just orthogonal
-//    if (U.determinant() < 0) U = -U;
-//    if (V.determinant() < 0) V = -V;
-//
-//    std::cout << "U:\n" << U << std::endl;
-//    std::cout << "s:\n" << s << std::endl;
-//    std::cout << "V:\n" << V << std::endl;
-//
-//
-//    mat R0 = TODO;
-//    mat R1 = TODO;
-//
-//    std::cout << "R0:\n" << R0 << std::endl;
-//    std::cout << "R1:\n" << R1 << std::endl;
-//
-//    vec t0 = TODO;
-//    vec t1 = TODO;
-//
-//    std::cout << "t0:\n" << t0 << std::endl;
-//
-//    P0 = matrix34d::eye();
-//
-//    // 4 possible solutions
-//    matrix34d P10 = composeP(R0, t0);
-//    matrix34d P11 = composeP(R0, t1);
-//    matrix34d P12 = composeP(R1, t0);
-//    matrix34d P13 = composeP(R1, t1);
-//    matrix34d P1s[4] = {P10, P11, P12, P13};
-//
-//    // need to select best of 4 solutions: 3d points should be in front of cameras (positive depths)
-//    int best_count = 0;
-//    int best_idx = -1;
-//    for (int i = 0; i < 4; ++i) {
-//        int count = 0;
-//        for (int j = 0; j < (int) m0.size(); ++j) {
-//            if (depthTest(m0[j], m1[j], calib0, calib1, P0, P1s[i])) {
-//                ++count;
-//            }
-//        }
-//        std::cout << "decomposeEMatrix: count: " << count << std::endl;
-//        if (count > best_count) {
-//            best_count = count;
-//            best_idx = i;
-//        }
-//    }
-//
-//    if (best_count == 0) {
-//        throw std::runtime_error("decomposeEMatrix : can't decompose ematrix");
-//    }
-//
-//    P1 = P1s[best_idx];
-//
-//    std::cout << "best idx: " << best_idx << std::endl;
-//    std::cout << "P0: \n" << P0 << std::endl;
-//    std::cout << "P1: \n" << P1 << std::endl;
+//    throw std::runtime_error("not implemented yet");
+    if (m0.size() != m1.size()) {
+        throw std::runtime_error("decomposeEMatrix : m0.size() != m1.size()");
+    }
+
+    using mat = Eigen::MatrixXd;
+    using vec = Eigen::VectorXd;
+
+    mat E;
+    copy(Ecv, E);
+
+    // (см. Hartley & Zisserman p.258)
+
+    Eigen::JacobiSVD<mat> svd(E, Eigen::ComputeFullU | Eigen::ComputeFullV);
+
+    Eigen::Matrix3d W = Eigen::Matrix3d::Zero();
+    W(0, 1) = -1.0;
+    W(1, 0) = 1.0;
+    W(2, 2) = 1.0;
+
+    mat U = svd.matrixU();
+    vec s = svd.singularValues();
+    mat V = svd.matrixV();
+
+    // U, V must be rotation matrices, not just orthogonal
+    if (U.determinant() < 0) U = -U;
+    if (V.determinant() < 0) V = -V;
+
+    std::cout << "U:\n" << U << std::endl;
+    std::cout << "s:\n" << s << std::endl;
+    std::cout << "V:\n" << V << std::endl;
+
+
+    mat R0 = U * W * V.transpose();
+    mat R1 =  U * W.transpose() * V.transpose();
+
+    std::cout << "R0:\n" << R0 << std::endl;
+    std::cout << "R1:\n" << R1 << std::endl;
+
+    vec t0 = U(Eigen::all, 2);
+    vec t1 = U(Eigen::all, 2) * -1.0;
+
+    std::cout << "t0:\n" << t0 << std::endl;
+
+    P0 = matrix34d::eye();
+
+    // 4 possible solutions
+    matrix34d P10 = composeP(R0, t0);
+    matrix34d P11 = composeP(R0, t1);
+    matrix34d P12 = composeP(R1, t0);
+    matrix34d P13 = composeP(R1, t1);
+    matrix34d P1s[4] = {P10, P11, P12, P13};
+
+    // need to select best of 4 solutions: 3d points should be in front of cameras (positive depths)
+    int best_count = 0;
+    int best_idx = -1;
+    for (int i = 0; i < 4; ++i) {
+        int count = 0;
+        for (int j = 0; j < (int) m0.size(); ++j) {
+            if (depthTest(m0[j], m1[j], calib0, calib1, P0, P1s[i])) {
+                ++count;
+            }
+        }
+        std::cout << "decomposeEMatrix: count: " << count << std::endl;
+        if (count > best_count) {
+            best_count = count;
+            best_idx = i;
+        }
+    }
+
+    if (best_count == 0) {
+        throw std::runtime_error("decomposeEMatrix : can't decompose ematrix");
+    }
+
+    P1 = P1s[best_idx];
+
+    std::cout << "best idx: " << best_idx << std::endl;
+    std::cout << "P0: \n" << P0 << std::endl;
+    std::cout << "P1: \n" << P1 << std::endl;
 }
 
 void phg::decomposeUndistortedPMatrix(cv::Matx33d &R, cv::Vec3d &O, const cv::Matx34d &P)

--- a/src/phg/sfm/resection.cpp
+++ b/src/phg/sfm/resection.cpp
@@ -27,13 +27,16 @@ namespace {
         }
         sc = std::sqrt(3 / sc);
 
+        tt *= sc;
+        RR *= sc;
+
         Eigen::MatrixXd RRe;
         copy(RR, RRe);
         Eigen::JacobiSVD<Eigen::MatrixXd> svd(RRe, Eigen::ComputeFullU | Eigen::ComputeFullV);
         RRe = svd.matrixU() * svd.matrixV().transpose();
         copy(RRe, RR);
 
-        tt *= sc;
+
 
         matrix34d result;
         for (int i = 0; i < 9; ++i) {
@@ -49,95 +52,126 @@ namespace {
     // (см. Hartley & Zisserman p.178)
     cv::Matx34d estimateCameraMatrixDLT(const cv::Vec3d *Xs, const cv::Vec3d *xs, int count)
     {
-        throw std::runtime_error("not implemented yet");
-//        using mat = Eigen::MatrixXd;
-//        using vec = Eigen::VectorXd;
-//
-//        mat A(TODO);
-//
-//        for (int i = 0; i < count; ++i) {
-//
-//            double x = xs[i][0];
-//            double y = xs[i][1];
-//            double w = xs[i][2];
-//
-//            double X = Xs[i][0];
-//            double Y = Xs[i][1];
-//            double Z = Xs[i][2];
-//            double W = 1.0;
-//
-//            TODO
-//        }
-//
-//        matrix34d result;
-//          TODO
-//
+        using mat = Eigen::MatrixXd;
+        using vec = Eigen::VectorXd;
+
+        std::vector<std::vector<double>> Av;
+        for (int i = 0; i < count; ++i) {
+
+            double x = xs[i][0];
+            double y = xs[i][1];
+            double w = xs[i][2];
+
+            double X = Xs[i][0];
+            double Y = Xs[i][1];
+            double Z = Xs[i][2];
+            double W = 1.0;
+            Av.push_back({
+                                 0.0, 0.0, 0.0, 0.0, -w * X, -w * Y, -w * Z, -w * W, y * X, y * Y, y * Z, y * W
+                         });
+            Av.push_back({
+                                 w * X, w * Y, w * Z, w * W, 0.0, 0.0, 0.0, 0.0, -x * X, -x * Y, -x * Z, -x * W
+                         });
+        }
+        mat A;
+        A.resize(Av.size(), Av[0].size());
+        for (int y = 0; y < Av.size(); ++y) {
+            for (int x = 0; x < 12; ++x) {
+                A(y, x) = Av[y][x];
+            }
+        }
+
+        Eigen::JacobiSVD<Eigen::MatrixXd> svd(A, Eigen::ComputeFullU | Eigen::ComputeFullV);
+        auto V = svd.matrixV();
+        matrix34d result;
+        Eigen::Matrix<double, 12, 1> check;
+        for (int i = 0; i < 12; ++i) {
+            result(i / 4, i % 4) = V(i, 11);
+            check(i) = V(i, 11);
+        }
+        for (int i = 0; i < count; ++i) {
+            cv::Vec4d Xi;
+            Xi(3) = 1.0;
+            for (int j = 0; j < 3; ++j)
+                Xi(j) = Xs[i](j);
+            auto px_homogen = result * Xi;
+            cv::Vec2d px = cv::Matx23d::eye() * (px_homogen / px_homogen(2));
+//            std::cout << i << " norm = " << cv::norm(px - xs[i]) << std::endl;
+        }
+
 //        return canonicalizeP(result);
+        return result;
     }
 
 
     // По трехмерным точкам и их проекциям на изображении определяем положение камеры
     cv::Matx34d estimateCameraMatrixRANSAC(const phg::Calibration &calib, const std::vector<cv::Vec3d> &X, const std::vector<cv::Vec2d> &x)
     {
-        throw std::runtime_error("not implemented yet");
-//        if (X.size() != x.size()) {
-//            throw std::runtime_error("estimateCameraMatrixRANSAC: X.size() != x.size()");
-//        }
-//
-//        const int n_points = X.size();
-//
-//        // https://en.wikipedia.org/wiki/Random_sample_consensus#Parameters
-//        // будет отличаться от случая с гомографией
-//        const int n_trials = TODO;
-//
-//        const double threshold_px = 3;
-//
-//        const int n_samples = TODO;
-//        uint64_t seed = 1;
-//
-//        int best_support = 0;
-//        cv::Matx34d best_P;
-//
-//        std::vector<int> sample;
-//        for (int i_trial = 0; i_trial < n_trials; ++i_trial) {
-//            phg::randomSample(sample, n_points, n_samples, &seed);
-//
-//            cv::Vec3d ms0[n_samples];
-//            cv::Vec3d ms1[n_samples];
-//            for (int i = 0; i < n_samples; ++i) {
-//                ms0[i] = TODO;
-//                ms1[i] = TODO;
-//            }
-//
-//            cv::Matx34d P = estimateCameraMatrixDLT(ms0, ms1, n_samples);
-//
-//            int support = 0;
-//            for (int i = 0; i < n_points; ++i) {
-//                cv::Vec2d px = TODO спроецировать 3Д точку в пиксель с использованием P и calib;
-//                if (cv::norm(px - x[i]) < threshold_px) {
-//                    ++support;
-//                }
-//            }
-//
-//            if (support > best_support) {
-//                best_support = support;
-//                best_P = P;
-//
-//                std::cout << "estimateCameraMatrixRANSAC : support: " << best_support << "/" << n_points << std::endl;
-//
-//                if (best_support == n_points) {
-//                    break;
-//                }
-//            }
-//        }
-//
-//        std::cout << "estimateCameraMatrixRANSAC : best support: " << best_support << "/" << n_points << std::endl;
-//
-//        if (best_support == 0) {
-//            throw std::runtime_error("estimateCameraMatrixRANSAC : failed to estimate camera matrix");
-//        }
-//
+//        throw std::runtime_error("not implemented yet");
+        if (X.size() != x.size()) {
+            throw std::runtime_error("estimateCameraMatrixRANSAC: X.size() != x.size()");
+        }
+
+        const int n_points = X.size();
+
+        // https://en.wikipedia.org/wiki/Random_sample_consensus#Parameters
+        // будет отличаться от случая с гомографией
+        const int n_trials = 1000;
+
+        const double threshold_px = 3;
+
+        const int n_samples = 10;
+        uint64_t seed = 1;
+
+        int best_support = 0;
+        cv::Matx34d best_P;
+
+        std::vector<int> sample;
+        for (int i_trial = 0; i_trial < n_trials; ++i_trial) {
+            phg::randomSample(sample, n_points, n_samples, &seed);
+
+            cv::Vec3d ms0[n_samples];
+            cv::Vec3d ms1[n_samples];
+            for (int i = 0; i < n_samples; ++i) {
+                ms0[i] = X[sample[i]];
+                ms1[i] = calib.unproject(x[sample[i]]);
+            }
+
+            cv::Matx34d P = estimateCameraMatrixDLT(ms0, ms1, n_samples);
+//            P = calib.K() * canonicalizeP(calib.K().inv() * P);
+            int support = 0;
+            for (int i = 0; i < n_points; ++i) {
+                cv::Vec4d Xi;
+                Xi(3) = 1.0;
+                for (int j = 0; j < 3; ++j)
+                    Xi(j) = X[i](j);
+                auto px_homogen = calib.K() * P * Xi;
+                cv::Vec2d px = cv::Matx23d::eye() * (px_homogen / px_homogen(2));
+                if (cv::norm(px - x[i]) < threshold_px) {
+                    ++support;
+                }
+            }
+
+            if (support > best_support) {
+                best_support = support;
+                best_P = P;
+
+                std::cout << "estimateCameraMatrixRANSAC : support: " << best_support << "/" << n_points << std::endl;
+
+                if (best_support == n_points) {
+                    break;
+                }
+            }
+        }
+
+        std::cout << "estimateCameraMatrixRANSAC : best support: " << best_support << "/" << n_points << std::endl;
+
+        if (best_support == 0) {
+            throw std::runtime_error("estimateCameraMatrixRANSAC : failed to estimate camera matrix");
+        }
+
 //        return best_P;
+        return canonicalizeP(best_P);
     }
 
 

--- a/src/phg/sfm/sfm_utils.cpp
+++ b/src/phg/sfm/sfm_utils.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <stdexcept>
+#include <iostream>
 
 
 // pseudorandom number generator
@@ -41,5 +42,18 @@ void phg::randomSample(std::vector<int> &dst, int max_id, int sample_size, uint6
 // проверяет, что расстояние от точки до линии меньше порога
 bool phg::epipolarTest(const cv::Vec2d &pt0, const cv::Vec2d &pt1, const cv::Matx33d &F, double t)
 {
-    throw std::runtime_error("not implemented yet");
+//    cv::Mat pt0_v{3, 1, CV_64FC1};
+//    cv::Mat line_vec = F * pt0_v;
+    cv::Matx31d pt0_v{pt0[0], pt0[1], 1.0};
+    auto line_vec = F * pt0_v;
+    double a_ = line_vec(0, 0);
+    double b_ = line_vec(0, 1);
+    double c_ = line_vec(0, 2);
+    auto norm = std::sqrt(a_  * a_  + b_ * b_);
+    double a = a_ / norm;
+    double b = b_ / norm;
+    double c = c_ / norm;
+    double oriented_dist = a * pt1[0] + b * pt1[1] + c;
+//    std::cout << "Distance to line is " << std::abs(oriented_dist) << std::endl;
+    return std::abs(oriented_dist) < t;
 }

--- a/src/phg/sfm/triangulation.cpp
+++ b/src/phg/sfm/triangulation.cpp
@@ -3,6 +3,7 @@
 #include "defines.h"
 
 #include <Eigen/SVD>
+#include <iostream>
 
 // По положениям камер и ключевых точкам определяем точку в трехмерном пространстве
 // Задача эквивалентна поиску точки пересечения двух (или более) лучей
@@ -10,7 +11,29 @@
 // (см. Hartley & Zisserman p.312)
 cv::Vec4d phg::triangulatePoint(const cv::Matx34d *Ps, const cv::Vec3d *ms, int count)
 {
-    // составление однородной системы + SVD
-    // без подвохов
-    throw std::runtime_error("not implemented yet");
+    Eigen::MatrixX4d A;
+    A.resize(2 * count, 4);
+    for (int i = 0; i < count; ++i) {
+        auto p1 = Ps[i].row(0);
+        auto p2 = Ps[i].row(1);
+        auto p3 = Ps[i].row(2);
+        auto x = ms[i][0];
+        auto y = ms[i][1];
+        auto w = ms[i][2];
+        auto row1 = p3 * x - p1 * w;
+        auto row2 =  p3 * y - p2 * w;
+        for (int x_iter = 0; x_iter < 4; ++x_iter) {
+            A(2 * i, x_iter) = row1(0, x_iter);
+            A(2 * i + 1, x_iter) = row2(0, x_iter);
+        }
+    }
+    Eigen::JacobiSVD<Eigen::MatrixXd> svd(A, Eigen::ComputeFullV);
+    auto V = svd.matrixV();
+    cv::Vec4d result;
+    for (int i = 0; i < 4; ++i) {
+        result[i] = V(i, 3);
+    }
+//    std::cout << "First matrix projection: " << Ps[0] * result << std::endl;
+//    std::cout << "Second matrix projection: " << Ps[1] * result << std::endl;
+    return result;
 }


### PR DESCRIPTION
# Перечислите идеи и коротко обозначьте мысли которые у вас возникали по мере выполнения задания, в частности попробуйте ответить на вопросы:

1) Мы можем получить облако точек и взаимную ориентацию по двум камерам. Почему для выравнивания трёх камер мы использовали резекцию, а не посчитали E матрицу для второй пары камер и не разложили ее?
При E-декомпозиции мы получаем матрицу P_nocalib с точностью до домножения сдвига на константу (если мы увеличим сдвиг в k раз, то из соображений гомотетии образы триангуляции тоже сдвинутся в k раз в предположении, что первая камера имеет матрицу ( I |0) ). Эти масштабы по умолчанию не будут сходиться у разных пар камер. К тому же, у нас тогда будут уточняться точки только на парах камер, в то время как наш способ позволит уточнять положения точек, используя все уже имеющиеся камеры. 

2) Как реализовать выравнивание если мы все же хотим использовать Е матрицу?
Чтобы поправить проблему с масштабом, можно, например, найти несколько точек, который присутствуют на всех трех камерах, и проверять, что в результате декомпозиции камер (1 и 2 ) и (2 и 3) точки имеют в среднем одинаковое расстояние до камеры 2 в этих случаях (иначе домножаем сдвиг во второй декомпозиции). 

3) Если есть, фидбек по заданию: какая часть больше всего понравилась, где-то слишком сложно/просто (что именно), где-то слишком мало ссылок и тд.


// Создайте PR.
// Дождитесь отработки Travis CI, после чего нажмите на зеленую галочку -> Details -> The build -> скопируйте весь лог тестирования.
// Откройте PR на редактирование (сверху справа три точки->Edit) и добавьте сюда скопированный лог тестирования внутри тега <pre> для сохранения форматирования и под спойлером для компактности и удобства:

<details><summary>Travis CI</summary><p>

<pre>
Running main() from /home/runner/work/PhotogrammetryTasks2024/PhotogrammetryTasks2024/libs/3rdparty/libgtest/googletest/src/gtest_main.cc
[==========] Running 8 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 8 tests from SFM
[ RUN      ] SFM.EpipolarDist
[       OK ] SFM.EpipolarDist (0 ms)
[ RUN      ] SFM.FmatrixSimple
estimateFMatrixRANSAC : support: 8/8
estimateFMatrixRANSAC : best support: 8/8
F=[0.0003754348499906659, 0.0008884002240560467, -0.07460737414631842;
 -0.0008428774277812341, 0.0005145488947145285, 0.06318808727448025;
 0.0001091944160515114, -0.07038498768911644, 2.915189566241405]
Fcv=[-0.003528898837466964, 0.005635136333436428, -0.1423486302494478;
 -0.001383168994964197, -0.001374080912309598, 0.268712766335525;
 0.2737904137083788, -0.3263083936950661, 1]
0 F gives [-0.02902665205605537], Fcv gives [1.77635683940025e-15]
1 F gives [-0.01905929599749046], Fcv gives [-3.552713678800501e-15]
2 F gives [-0.003232937163110836], Fcv gives [-4.440892098500626e-16]
3 F gives [-0.03718745630600225], Fcv gives [3.219646771412954e-15]
4 F gives [0.004799723166659109], Fcv gives [6.661338147750939e-16]
5 F gives [0.03403143127195246], Fcv gives [2.664535259100376e-15]
6 F gives [-0.03323020942015104], Fcv gives [-6.661338147750939e-16]
7 F gives [-0.0239376644404099], Fcv gives [2.913961822623917]
checkFmatrixSpectralProperty: s:     2.91768  0.00241765 2.07035e-19
checkFmatrixSpectralProperty: s:     1.12307    0.112607 3.18992e-19
[       OK ] SFM.FmatrixSimple (5 ms)
[ RUN      ] SFM.MyFTest
estimateFMatrixRANSAC : support: 8/8
estimateFMatrixRANSAC : best support: 8/8
F=[-3.796909722729968e-16, 0.005219227447129528, 3.898791012257874e-16;
 5.476220468403845e-16, -1.070244940490088e-17, -0.007381102240841038;
 -3.796909722730037e-16, 0.005219227447130462, -4.488596994089988e-16]
Fcv=[0.9331592045822739, -250900.9021895911, -0.9466108111347161;
 0.3024355806465136, 0.03075426239357942, 354827.0559377287;
 0.9331599056846587, -250900.644736916, 1]
0 F gives [-5.551115123125783e-16], Fcv gives [-0.1727437525987625]
1 F gives [-1.734723475976807e-17], Fcv gives [0.004779278737260029]
2 F gives [1.665334536937735e-16], Fcv gives [-1.199349138885736]
3 F gives [-2.688821387764051e-17], Fcv gives [-0.005782106061815284]
4 F gives [-2.081668171172169e-17], Fcv gives [0.008460813201963902]
5 F gives [-5.925164872633282e-17], Fcv gives [-0.0006644590284849983]
6 F gives [1.110223024625157e-16], Fcv gives [-0.4499464482069016]
7 F gives [4.440892098500626e-16], Fcv gives [-0.3269713893532753]
checkFmatrixSpectralProperty: s:   0.0073811   0.0073811 8.23771e-31
checkFmatrixSpectralProperty: s:      354827      354827 3.94171e-10
[       OK ] SFM.MyFTest (6 ms)
[ RUN      ] SFM.TriangulationSimple
P1:
[0.7071067811865476, 0, 0.7071067811865475, -1.414213562373095;
 0, 1, 0, 0;
 -0.7071067811865475, 0, 0.7071067811865476, 1.414213562373095]
x2:
[0, 0, 2]
x3:
[-2.22045e-16, 0, 2.82843]
X1:
[-5.55112e-17, 6.25241e-17, 0.894427, 0.447214]
|X - X1| = 9.07642e-16
[       OK ] SFM.TriangulationSimple (0 ms)
[ RUN      ] SFM.FmatrixMatchFiltering
detecting points...
matching points...
filtering matches GMS...
Get total 4728 matches.
filtering matches F...
estimateFMatrixRANSAC : support: 86/16740
estimateFMatrixRANSAC : support: 121/16740
estimateFMatrixRANSAC : support: 217/16740
estimateFMatrixRANSAC : support: 747/16740
estimateFMatrixRANSAC : support: 760/16740
estimateFMatrixRANSAC : support: 1038/16740
estimateFMatrixRANSAC : support: 1297/16740
estimateFMatrixRANSAC : support: 1963/16740
estimateFMatrixRANSAC : support: 4013/16740
estimateFMatrixRANSAC : best support: 4013/16740
estimateFMatrixRANSAC : support: 1556/4728
estimateFMatrixRANSAC : support: 3133/4728
estimateFMatrixRANSAC : support: 3609/4728
estimateFMatrixRANSAC : support: 3909/4728
estimateFMatrixRANSAC : support: 4075/4728
estimateFMatrixRANSAC : support: 4110/4728
estimateFMatrixRANSAC : support: 4150/4728
estimateFMatrixRANSAC : support: 4151/4728
estimateFMatrixRANSAC : support: 4153/4728
estimateFMatrixRANSAC : best support: 4153/4728
n matches gms: 4728
n matches F: 4013
n matches gms + F: 4153
[       OK ] SFM.FmatrixMatchFiltering (26982 ms)
[ RUN      ] SFM.RelativePosition2View
detecting points...
matching points...
filtering matches GMS...
Get total 4659 matches.
estimateFMatrixRANSAC : support: 3990/4659
estimateFMatrixRANSAC : support: 4048/4659
estimateFMatrixRANSAC : support: 4049/4659
estimateFMatrixRANSAC : support: 4050/4659
estimateFMatrixRANSAC : support: 4051/4659
estimateFMatrixRANSAC : best support: 4051/4659
singularValues =     5.84557
    5.81111
1.24283e-18
U:
 0.0636037 -0.0939254   0.993545
  0.690976   0.722477  0.0240656
 -0.720074   0.684986   0.110852
s:
    5.84557
    5.81111
1.24283e-18
V:
   0.0999578      0.10337     0.989608
    0.721586    -0.692325 -0.000568546
    0.685071     0.714144    -0.143794
R0:
   0.967257  -0.0243057   -0.252633
  0.0246066    0.999695 -0.00196908
   0.252604 -0.00431183     0.96756
R1:
   0.999183    0.023176  -0.0330976
  0.0230244   -0.999723 -0.00495188
 -0.0332032  0.00418578    -0.99944
t0:
 0.993545
0.0240656
 0.110852
decomposeEMatrix: count: 3444
decomposeEMatrix: count: 806
decomposeEMatrix: count: 325
decomposeEMatrix: count: 84
best idx: 0
P0: 
[1, 0, 0, 0;
 0, 1, 0, 0;
 0, 0, 1, 0]
P1: 
[0.9672567952837924, -0.02430572024463122, -0.2526331806012763, 0.9935454608408748;
 0.02460655649726783, 0.9996952736236968, -0.001969078918600033, 0.02406560159495355;
 0.2526040564889529, -0.004311827667083829, 0.9675601267040173, 0.1108524427442472]
Camera positions: 
R0:
[1, 0, 0;
 0, 1, 0;
 0, 0, 1]
O0: [0, 0, 0]
R1:
[0.9672567952837924, -0.02430572024463122, -0.2526331806012763;
 0.02460655649726783, 0.9996952736236968, -0.001969078918600033;
 0.2526040564889529, -0.004311827667083829, 0.9675601267040173]
O1: [-0.9896075467158965, 0.0005685464797240084, 0.1437935333658814]
relative_cos_vals: [0.96756, -0.143794, -0.389135]
exporting point cloud...
exporting 4663 points...
[       OK ] SFM.RelativePosition2View (8206 ms)
[ RUN      ] SFM.Resection
detecting points...
matching points...
filtering matches GMS...
Get total 4698 matches.
estimateFMatrixRANSAC : support: 3249/4698
estimateFMatrixRANSAC : support: 3307/4698
estimateFMatrixRANSAC : support: 3492/4698
estimateFMatrixRANSAC : support: 3797/4698
estimateFMatrixRANSAC : support: 3946/4698
estimateFMatrixRANSAC : support: 4053/4698
estimateFMatrixRANSAC : support: 4071/4698
estimateFMatrixRANSAC : support: 4076/4698
estimateFMatrixRANSAC : support: 4077/4698
estimateFMatrixRANSAC : support: 4078/4698
estimateFMatrixRANSAC : support: 4079/4698
estimateFMatrixRANSAC : best support: 4079/4698
singularValues =     5.99028
    5.96739
3.15176e-17
U:
 0.0691266 -0.0930715   0.993257
  0.662757   0.748449   0.024007
 -0.745637   0.656629   0.113422
s:
    5.99028
    5.96739
3.15176e-17
V:
  0.0957643    0.108235    0.989502
    0.74714   -0.664667 0.000394947
   0.657732    0.739259   -0.144518
R0:
   0.966435   -0.023199   -0.255862
  0.0236963    0.999719 -0.00113945
   0.255816 -0.00496178    0.966713
R1:
   0.999225   0.0239836  -0.0312249
  0.0238137     -0.9997 -0.00579945
 -0.0313546  0.00505137   -0.999496
t0:
0.993257
0.024007
0.113422
decomposeEMatrix: count: 3532
decomposeEMatrix: count: 761
decomposeEMatrix: count: 322
decomposeEMatrix: count: 83
best idx: 0
P0: 
[1, 0, 0, 0;
 0, 1, 0, 0;
 0, 0, 1, 0]
P1: 
[0.9664349186011235, -0.02319900324163526, -0.2558619830241188, 0.9932568683205306;
 0.02369630020324961, 0.9997185538988858, -0.001139450304816944, 0.02400704593147994;
 0.2558164057778886, -0.00496177779775249, 0.9667126498065324, 0.1134215820720907]
Camera positions: 
R0:
[1, 0, 0;
 0, 1, 0;
 0, 0, 1]
O0: [0, 0, 0]
R1:
[0.9664349186011235, -0.02319900324163526, -0.2558619830241188;
 0.02369630020324961, 0.9997185538988858, -0.001139450304816944;
 0.2558164057778886, -0.00496177779775249, 0.9667126498065324]
O1: [-0.9895021003160686, -0.0003949472463475157, 0.1445179486664614]
estimateCameraMatrixRANSAC : support: 3759/4698
estimateCameraMatrixRANSAC : support: 4102/4698
estimateCameraMatrixRANSAC : support: 4112/4698
estimateCameraMatrixRANSAC : support: 4115/4698
estimateCameraMatrixRANSAC : support: 4117/4698
estimateCameraMatrixRANSAC : support: 4121/4698
estimateCameraMatrixRANSAC : support: 4151/4698
estimateCameraMatrixRANSAC : best support: 4151/4698
estimateCameraMatrixRANSAC : support: 3731/4698
estimateCameraMatrixRANSAC : support: 3841/4698
estimateCameraMatrixRANSAC : support: 4110/4698
estimateCameraMatrixRANSAC : support: 4113/4698
estimateCameraMatrixRANSAC : support: 4114/4698
estimateCameraMatrixRANSAC : support: 4115/4698
estimateCameraMatrixRANSAC : support: 4116/4698
estimateCameraMatrixRANSAC : support: 4117/4698
estimateCameraMatrixRANSAC : best support: 4117/4698
P0s: 
[1, 0, 0, 0;
 0, 1, 0, 0;
 0, 0, 1, 0]
[0.9999841114722074, 0.002369512981624133, 0.005114900914970466, -0.000230421795847629;
 -0.002361873329579656, 0.9999960870725142, -0.00149913109356728, -0.0006985929485945714;
 -0.005118433111321097, 0.001487026526526575, 0.9999857950964074, -0.009899528482625555]
P01s: 
[0.9664349186011235, -0.02319900324163526, -0.2558619830241188, 0.9932568683205306;
 0.02369630020324961, 0.9997185538988858, -0.001139450304816944, 0.02400704593147994;
 0.2558164057778886, -0.00496177779775249, 0.9667126498065324, 0.1134215820720907]
[0.9663530451074134, -0.02385541899930233, -0.2561107401027846, 0.993380096873005;
 0.02440941863325895, 0.9997015295725447, -0.001015899749226667, 0.02547801276967464;
 0.2560585333348893, -0.005269796455454112, 0.9666469142099938, 0.1189264205049298]
[       OK ] SFM.Resection (8768 ms)
[ RUN      ] SFM.ReconstructNViews
detecting points...
matching points...
flann matching...
filtering matches GMS...
Get total 4735 matches.
flann matching...
filtering matches GMS...
Get total 2071 matches.
flann matching...
filtering matches GMS...
Get total 4495 matches.
flann matching...
filtering matches GMS...
Get total 4876 matches.
flann matching...
filtering matches GMS...
Get total 2442 matches.
flann matching...
filtering matches GMS...
Get total 5063 matches.
estimateFMatrixRANSAC : support: 3864/4735
estimateFMatrixRANSAC : support: 4078/4735
estimateFMatrixRANSAC : support: 4079/4735
estimateFMatrixRANSAC : support: 4080/4735
estimateFMatrixRANSAC : best support: 4080/4735
singularValues =     5.90747
    5.88792
1.57131e-16
U:
 -0.131476 0.00946541   0.991274
  0.112955  -0.993299  0.0244662
  0.984863   0.115186   0.129525
s:
    5.90747
    5.88792
1.57131e-16
V:
 -0.0123571    0.132716    0.991077
   0.994094      0.1085 -0.00213461
  -0.107815    0.985198   -0.133273
R0:
   0.999761   0.0215587 -0.00360107
  0.0215314    -0.99974 -0.00745035
-0.00376076  0.00737103   -0.999966
R1:
   0.965097  -0.0257906   -0.260619
  0.0269645    0.999636 0.000928973
     0.2605 -0.00792401    0.965441
t0:
 0.991274
0.0244662
 0.129525
decomposeEMatrix: count: 317
decomposeEMatrix: count: 89
decomposeEMatrix: count: 3536
decomposeEMatrix: count: 793
best idx: 2
P0: 
[1, 0, 0, 0;
 0, 1, 0, 0;
 0, 0, 1, 0]
P1: 
[0.965097194024688, -0.02579063452976924, -0.2606189733235553, 0.9912742124437994;
 0.02696449000685919, 0.999635960381718, 0.0009289727598074601, 0.02446624663383829;
 0.2605001388950537, -0.007924006705596287, 0.9654412917176197, 0.1295254358015309]
estimateCameraMatrixRANSAC : support: 30/3888
estimateCameraMatrixRANSAC : support: 307/3888
estimateCameraMatrixRANSAC : support: 3362/3888
estimateCameraMatrixRANSAC : support: 3364/3888
estimateCameraMatrixRANSAC : best support: 3364/3888
relative_cos_vals: [0.965441, -0.133273, -0.386963]
relative_cos_vals: [0.971253, -0.551622, -0.733606]
exporting 8190 points...
[       OK ] SFM.ReconstructNViews (11789 ms)
[----------] 8 tests from SFM (55757 ms total)

[----------] Global test environment tear-down
[==========] 8 tests from 1 test suite ran. (55757 ms total)
[  PASSED  ] 8 tests.

</pre>

</p></details>