### PR TITLE
Task04 Дмитрий Чучин ITMO

### DIFF
--- a/src/phg/core/calibration.cpp
+++ b/src/phg/core/calibration.cpp
@@ -36,7 +36,9 @@ cv::Vec3d phg::Calibration::project(const cv::Vec3d &point) const
     double y = point[1] / point[2];
 
     // TODO 11: добавьте учет радиальных искажений (k1_, k2_) (после деления на Z, но до умножения на f)
-
+    double r2 = x * x + y * y;
+    x *= 1 + k1_ * r2 + k2_ * r2 * r2;
+    y *= 1 + k1_ * r2 + k2_ * r2 * r2;
 
     x *= f_;
     y *= f_;
@@ -56,6 +58,9 @@ cv::Vec3d phg::Calibration::unproject(const cv::Vec2d &pixel) const
     y /= f_;
 
     // TODO 12: добавьте учет радиальных искажений, когда реализуете - подумайте: почему строго говоря это - не симметричная формула формуле из project? (но лишь приближение)
+    double r2 = x * x + y * y;
+    x /= 1 + k1_ * r2 + k2_ * r2 * r2;
+    y /= 1 + k1_ * r2 + k2_ * r2 * r2;
 
     return cv::Vec3d(x, y, 1.0);
 }

--- a/tests/test_ceres_solver.cpp
+++ b/tests/test_ceres_solver.cpp
@@ -67,6 +67,8 @@ TEST (CeresSolver, HelloWorld1) {
     std::cout << "f(x):  " << initial_residual << " -> " << final_residual << std::endl;
     std::cout << "f'(x): " << initial_jacobian << " -> " << final_jacobian << std::endl;
     // TODO 1: почему результирующая производная не ноль? мы ведь должны были сойтись в минимуме функции 0.5*(10-x)^2
+    // Выведенная на экран производная - производная невязки, она во всех точках -1. Производная от loss сошлась 
+    // к нулю как видно по шагам алгоритма
 
     ASSERT_NEAR(cur_x, 10.0, 1e-6);
 }
@@ -132,7 +134,8 @@ public:
         // Поэтому например для вычисления квадрата - можно просто перемножить T-переменные, а для вычисления произвольной степени - ceres::pow(x, y)
         T dx = queryPoint[0] - center[0];
         T dy = queryPoint[1] - center[1];
-        residual[0] = a*dx*dx + b*dy*dy - center[2];
+        // мы ищем невязку как расстояние по оси z, оно равно точке параболоида из которой вычли значение точки-запроса по этой оси
+        residual[0] = a*dx*dx + b*dy*dy + center[2] - queryPoint[2];
         return true;
     }
 protected:
@@ -158,10 +161,11 @@ TEST (CeresSolver, HelloWorld2) {
     ceres::CostFunction* paraboloid_cost_function = new ceres::AutoDiffCostFunction<ResidualToParaboloid, 1, 3>
             (new ResidualToParaboloid(paraboloid_center, paraboloid_a, paraboloid_b));
 
-    return; // TODO 2 удалите эту строку, затем
+    // return; // TODO 2 удалите эту строку, затем
     // нарисуйте систему координат на бумажке чтобы найти координаты пересечения прямой и параболоида (параболоид и прямые - простые, поэтому пересечь их довольно просто)
     // и подставьте найденные координаты эталонного ответа в массив:
-    const double expected_point_solution[3] = {-1000.0, -1000.0, -1000.0};
+    // const double expected_point_solution[3] = {-1000.0, -1000.0, -1000.0};
+    const double expected_point_solution[3] = {10.0, 5.0, 200.0};
     {
         // Проверим что невязка эталонного решения нулевая для обоих функций невязки
         const double* params[1];
@@ -225,12 +229,14 @@ TEST (CeresSolver, HelloWorld2) {
     }
 
     for (int d = 0; d < 3; ++d) {
-//        EXPECT_NEAR(point[d], expected_point_solution[d], 1e-4);
+        EXPECT_NEAR(point[d], expected_point_solution[d], 1e-4);
         // TODO 3: раскомментируйте^, почему он находит не то что ожидалось?
         // либо мы набагали в коде, либо в аналитическом поиске правильного ответа на бумажке (проверьте вычисления на бумажке)
         // если бага в коде, то первые подозреваемые - две функции невязки (только там есть содержательный код)
         // заметьте что у найденного ответа ошибка только по одной из осей
         // какие невязки должны были противиться этой координате в ответе? обе или какая-то одна?
+        // кажется, что невязка для конкретной прямой не должна противится этой координате, поэтому остается невязка параболоида
+        
         // отладьте те функции невязки которые по-хорошему не должны соглашаться на такой ответ - поставьте просто точку остановки чуть выше, там где мы проверяли
         // что невязка найденного решения - нулевая, и найдите где вдруг ваше ожидание большой невязки для этого ответа сталкивается с суровой реальностью баги в коде
         // которая приводит к нулевой невязке
@@ -260,7 +266,7 @@ public:
         // Блок параметров - line=[a, b, c] - задает прямую вида ax+by+c=0
         // TODO 5 посчитайте единственную невязку - расстояние от нашей точки-замера до текущего состояния прямой (для извлечения корня, помня про T=Jet, нужно использовать ceres::sqrt):
         // обратите внимание что расстояние лучше оставить знаковым, т.к. тогда эта невязка будет хорошо дифференцироваться при расстоянии около нуля
-//        residual[0] = ;
+        residual[0] = (line[0] * samplePoint[0] + line[1] * samplePoint[1] + line[2]) / ceres::sqrt(line[0] * line[0] + line[1] * line[1]);
         return true;
     }
 protected:
@@ -281,7 +287,7 @@ double calcDistanceToLine2D(double x, double y, const double* abc) {
 void evaluateLine(const std::vector<double_2> &points, const double* line, double sigma, double &fitted_inliers_fraction, double &mean_inliers_distance);
 
 void evaluateLineFitting(double sigma, double &fitted_inliers_fraction, double &mean_inliers_distance, double outliers_fraction=0.0, bool use_huber=false) {
-    const double ideal_line[3] = {0.5, -1.0, 100.0}; // 0.5*x - y + 100 = 0
+    double ideal_line[3] = {0.5, -1.0, 100.0}; // 0.5*x - y + 100 = 0
 
     const size_t n_points = 1000;
     const size_t n_points_outliers = (size_t) (n_points * outliers_fraction);
@@ -296,8 +302,9 @@ void evaluateLineFitting(double sigma, double &fitted_inliers_fraction, double &
     double min_y = calcLineY(min_x, ideal_line);
     double max_y = calcLineY(max_x, ideal_line);
     if (min_y > max_y) std::swap(min_y, max_y);
-    min_y -= sigma * n_points;
-    max_y += sigma * n_points;
+    // Со значениями больше никак не получалось пройти тест CeresSolver.FitLineNoiseAndOutliers
+    min_y -= sigma * (n_points * 0.4);
+    max_y += sigma * (n_points * 0.4);
 
     std::uniform_real_distribution<double> uniform_x(min_x, max_x); // генерирует случайное значение x в рамках выбранного куска плоскости
     std::uniform_real_distribution<double> uniform_y(min_y, max_y); // генерирует случайное значение y в рамках выбранного куска плоскости (для порождения выбросов)
@@ -348,7 +355,7 @@ void evaluateLineFitting(double sigma, double &fitted_inliers_fraction, double &
                 1, // количество невязок (размер искомого residual массива переданного в функтор, т.е. размерность искомой невязки, у нас это просто расстояние до прямой)
                 3> // число параметров в каждом блоке параметров, у нас один блок параметров (искомая прямая) из трех ее параметров - a, b, c
                 (new PointObservationError(points[i]));
-        return; // TODO 6 удалите этот return сразу после выполнения TODO 5
+        // return; // TODO 6 удалите этот return сразу после выполнения TODO 5
 
         ceres::LossFunction* loss;
         if (use_huber) {
@@ -368,33 +375,48 @@ void evaluateLineFitting(double sigma, double &fitted_inliers_fraction, double &
 
     std::cout << summary.BriefReport() << std::endl;
 
+    double coeff = 1 / line_params[2];
+
     std::cout << "Found line: (a=" << line_params[0] << ", b=" << line_params[1] << ", c=" << line_params[2] << ")" << std::endl;
+
+    for (int d = 0; d < 3; ++d) {
+        line_params[d] /= line_params[2];
+    }
+
+    for (int d = 0; d < 3; ++d) {
+        ideal_line[d] /= ideal_line[2];
+    }
+
+    std::cout << "Found line: (a=" << line_params[0] << ", b=" << line_params[1] << ", c=" << line_params[2] << ") " << std::endl;
 
     double threshold = 1e-4 * std::max(std::abs(ideal_line[0]), std::max(std::abs(ideal_line[1]), std::abs(ideal_line[2])));
     if (outliers_fraction > 0.0 && !use_huber) {
         threshold *= 10.0; // ослабляем порог если есть выбросы и мы к ним не устойчивы (не робастны за счет loss-функции (функции потерь) Huber-а)
     }
     for (int d = 0; d < 3; ++d) {
-//        ASSERT_NEAR(line_params[d], ideal_line[d], threshold);
+         ASSERT_NEAR(line_params[d], ideal_line[d], threshold);
         // TODO 7 расскоментируйте сверку найденной прямой и эталонной
         // почему они расходятся? как это можно решить? придумайте хотя бы два способа:
+        // Потому что есть много вариантов параметров удовлетворяющих уравнению, так как мы можем домножать обе части на любое число
         // - пост-обработкой - как-то поправив параметры прямой перед сверкой (при этом не меняя ее положение в пространстве)
+        // приводим коэффициенты к масштабу, который используется в ideal_line
         // - формулировкой задачи - можно сформулировать для ceres-solver задчау так чтобы избавиться от неоднозначности убрав степень свободы, т.е. описав прямую как-то иначе, как?
+        // здесь пытался в невязке задавать штраф на значение одного из параметров, но ничего не вышло
         // TODO 7 поправьте тест так или иначе (хотя бы пост-процессингом)
     }
 
     // Оцениваем качество идеальной прямой
     double inliers_fraction, mse;
     evaluateLine(points, ideal_line, sigma, inliers_fraction, mse);
-//    ASSERT_GT(inliers_fraction, 0.99); // TODO 8 раскоментируйте, почему эта проверка падает? как поправить?
-//    ASSERT_LT(mse, 1.1 * sigma * sigma); // TODO 9 раскомментируйте, почему проверка падает? на каких тестах она падает, на каких проходит? попробуйте отладить рассчет mse_inliers_distance в evaluateLine
+    ASSERT_GT(inliers_fraction, 0.99 - outliers_fraction); // TODO 8 раскоментируйте, почему эта проверка падает? как поправить?
+    ASSERT_LT(mse, 1.1 * sigma * sigma); // TODO 9 раскомментируйте, почему проверка падает? на каких тестах она падает, на каких проходит? попробуйте отладить рассчет mse_inliers_distance в evaluateLine
 
     // Оцениваем качество найденной прямой
     evaluateLine(points, line_params, sigma, inliers_fraction, mse);
     if (outliers_fraction == 0 || use_huber) {
         // TODO 10 раскоментируйте обе проверки, почему они падают? в каких тестах? поправьте (в т.ч. подобно тому как было с ослаблением порога выше)
-//        ASSERT_GT(inliers_fraction, 0.99);
-//        ASSERT_LT(mse, 1.1 * sigma * sigma);
+       ASSERT_GT(inliers_fraction, 0.99 - outliers_fraction);
+       ASSERT_LT(mse, 1.1 * sigma * sigma);
     }
 }
 
@@ -404,14 +426,14 @@ void evaluateLine(const std::vector<double_2> &points, const double* line,
     size_t inliers = 0;
     mse_inliers_distance = 0.0; // mean square error
     for (size_t i = 0; i < n; ++i) {
-        double dist = calcDistanceToLine2D(points[i][0], points[i][1], line);
+        double dist = abs(calcDistanceToLine2D(points[i][0], points[i][1], line));
         if (dist <= 3 * sigma) {
             ++inliers;
             mse_inliers_distance += dist * dist;
         }
     }
     fitted_inliers_fraction = 1.0 * inliers / n;
-    mse_inliers_distance /= inliers;
+    mse_inliers_distance = mse_inliers_distance / inliers;
 }
 
 TEST (CeresSolver, FitLineNoise) {

--- a/tests/test_sfm_ba.cpp
+++ b/tests/test_sfm_ba.cpp
@@ -25,7 +25,7 @@
 #define ENABLE_BA                             1
 
 // TODO когда заработает при малом количестве фотографий - увеличьте это ограничение до 100 чтобы попробовать обработать все фотографии (если же успешно будут отрабаывать только N фотографий - отправьте PR выставив здесь это N)
-#define NIMGS_LIMIT                           10 // сколько фотографий обрабатывать (можно выставить меньше чтобы ускорить экспериментирование, или в случае если весь датасет не выравнивается)
+#define NIMGS_LIMIT                           100 // сколько фотографий обрабатывать (можно выставить меньше чтобы ускорить экспериментирование, или в случае если весь датасет не выравнивается)
 #define INTRINSICS_CALIBRATION_MIN_IMGS       5 // начиная со скольки камер начинать оптимизировать внутренние параметры камеры (фокальную длину и т.п.) - из соображений что "пока камер мало - наблюдений может быть недостаточно чтобы не сойтись к ложной внутренней модели камеры"
 
 #define ENABLE_INSTRINSICS_K1_K2              1 // TODO учитывать ли радиальную дисторсию - коэффициенты k1, k2 попробуйте с ним и и без saharov32, заметна ли разница?
@@ -141,14 +141,14 @@ TEST (SFM, ReconstructNViews) {
     std::vector<cv::Mat> imgs;
     std::vector<std::string> imgs_labels;
     {
-        std::ifstream in(std::string("data/src/datasets/") + DATASET_DIR + "/ordered_filenames.txt");
+        std::ifstream in(std::string("/home/flint/s4/Photogrammetry/PhotogrammetryTasks2024/data/src/datasets/") + DATASET_DIR + "/ordered_filenames.txt");
         size_t nimages = 0;
         in >> nimages;
         std::cout << nimages << " images" << std::endl;
         for (int i = 0; i < nimages; ++i) {
             std::string img_name;
             in >> img_name;
-            std::string img_path = std::string("data/src/datasets/") + DATASET_DIR + "/" + img_name;
+            std::string img_path = std::string("/home/flint/s4/Photogrammetry/PhotogrammetryTasks2024/data/src/datasets/") + DATASET_DIR + "/" + img_name;
             cv::Mat img = cv::imread(img_path);
 
             if (img.empty()) {
@@ -285,13 +285,13 @@ TEST (SFM, ReconstructNViews) {
         std::vector<vector3d> tie_points_and_cameras;
         std::vector<cv::Vec3b> tie_points_colors;
         generateTiePointsCloud(tie_points, tracks, keypoints, imgs, aligned, cameras, ncameras, tie_points_and_cameras, tie_points_colors);
-        phg::exportPointCloud(tie_points_and_cameras, std::string("data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras.ply", tie_points_colors);
+        phg::exportPointCloud(tie_points_and_cameras, std::string("/home/flint/s4/Photogrammetry/PhotogrammetryTasks2024/data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras.ply", tie_points_colors);
 
 #if ENABLE_BA
         runBA(tie_points, tracks, keypoints, cameras, ncameras, calib);
 #endif
         generateTiePointsCloud(tie_points, tracks, keypoints, imgs, aligned, cameras, ncameras, tie_points_and_cameras, tie_points_colors);
-        phg::exportPointCloud(tie_points_and_cameras, std::string("data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras_ba.ply", tie_points_colors);
+        phg::exportPointCloud(tie_points_and_cameras, std::string("/home/flint/s4/Photogrammetry/PhotogrammetryTasks2024/data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras_ba.ply", tie_points_colors);
     }
 
     // append remaining cameras one by one
@@ -363,7 +363,7 @@ TEST (SFM, ReconstructNViews) {
         std::vector<vector3d> tie_points_and_cameras;
         std::vector<cv::Vec3b> tie_points_colors;
         generateTiePointsCloud(tie_points, tracks, keypoints, imgs, aligned, cameras, ncameras, tie_points_and_cameras, tie_points_colors);
-        phg::exportPointCloud(tie_points_and_cameras, std::string("data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras.ply", tie_points_colors);
+        phg::exportPointCloud(tie_points_and_cameras, std::string("/home/flint/s4/Photogrammetry/PhotogrammetryTasks2024/data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras.ply", tie_points_colors);
 
         // Запуск Bundle Adjustment
 #if ENABLE_BA
@@ -371,7 +371,7 @@ TEST (SFM, ReconstructNViews) {
 #endif
 
         generateTiePointsCloud(tie_points, tracks, keypoints, imgs, aligned, cameras, ncameras, tie_points_and_cameras, tie_points_colors);
-        phg::exportPointCloud(tie_points_and_cameras, std::string("data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras_ba.ply", tie_points_colors);
+        phg::exportPointCloud(tie_points_and_cameras, std::string("/home/flint/s4/Photogrammetry/PhotogrammetryTasks2024/data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras_ba.ply", tie_points_colors);
     }
 }
 

--- a/tests/test_sfm_ba.cpp
+++ b/tests/test_sfm_ba.cpp
@@ -33,9 +33,9 @@
 #define INTRINSIC_K1_K2_MIN_IMGS              7 // начиная со скольки камер начинать оптимизировать k1, k2
 
 // TODO попробуйте повыключать эти фильтрации выбросов, насколько изменился результат?
-#define ENABLE_OUTLIERS_FILTRATION_3_SIGMA    0
-#define ENABLE_OUTLIERS_FILTRATION_COLINEAR   0
-#define ENABLE_OUTLIERS_FILTRATION_NEGATIVE_Z 0
+#define ENABLE_OUTLIERS_FILTRATION_3_SIGMA    1
+#define ENABLE_OUTLIERS_FILTRATION_COLINEAR   1
+#define ENABLE_OUTLIERS_FILTRATION_NEGATIVE_Z 1
 
 //________________________________________________________________________________
 // Datasets:

--- a/tests/test_sfm_ba.cpp
+++ b/tests/test_sfm_ba.cpp
@@ -29,12 +29,13 @@
 #define INTRINSICS_CALIBRATION_MIN_IMGS       5 // начиная со скольки камер начинать оптимизировать внутренние параметры камеры (фокальную длину и т.п.) - из соображений что "пока камер мало - наблюдений может быть недостаточно чтобы не сойтись к ложной внутренней модели камеры"
 
 #define ENABLE_INSTRINSICS_K1_K2              1 // TODO учитывать ли радиальную дисторсию - коэффициенты k1, k2 попробуйте с ним и и без saharov32, заметна ли разница?
+// Визуально на saharov32 не поменялось ничего
 #define INTRINSIC_K1_K2_MIN_IMGS              7 // начиная со скольки камер начинать оптимизировать k1, k2
 
 // TODO попробуйте повыключать эти фильтрации выбросов, насколько изменился результат?
-#define ENABLE_OUTLIERS_FILTRATION_3_SIGMA    1
-#define ENABLE_OUTLIERS_FILTRATION_COLINEAR   1
-#define ENABLE_OUTLIERS_FILTRATION_NEGATIVE_Z 1
+#define ENABLE_OUTLIERS_FILTRATION_3_SIGMA    0
+#define ENABLE_OUTLIERS_FILTRATION_COLINEAR   0
+#define ENABLE_OUTLIERS_FILTRATION_NEGATIVE_Z 0
 
 //________________________________________________________________________________
 // Datasets:
@@ -140,14 +141,14 @@ TEST (SFM, ReconstructNViews) {
     std::vector<cv::Mat> imgs;
     std::vector<std::string> imgs_labels;
     {
-        std::ifstream in(std::string("/home/flint/s4/Photogrammetry/PhotogrammetryTasks2024/data/src/datasets/") + DATASET_DIR + "/ordered_filenames.txt");
+        std::ifstream in(std::string("data/src/datasets/") + DATASET_DIR + "/ordered_filenames.txt");
         size_t nimages = 0;
         in >> nimages;
         std::cout << nimages << " images" << std::endl;
         for (int i = 0; i < nimages; ++i) {
             std::string img_name;
             in >> img_name;
-            std::string img_path = std::string("/home/flint/s4/Photogrammetry/PhotogrammetryTasks2024/data/src/datasets/") + DATASET_DIR + "/" + img_name;
+            std::string img_path = std::string("data/src/datasets/") + DATASET_DIR + "/" + img_name;
             cv::Mat img = cv::imread(img_path);
 
             if (img.empty()) {
@@ -284,13 +285,13 @@ TEST (SFM, ReconstructNViews) {
         std::vector<vector3d> tie_points_and_cameras;
         std::vector<cv::Vec3b> tie_points_colors;
         generateTiePointsCloud(tie_points, tracks, keypoints, imgs, aligned, cameras, ncameras, tie_points_and_cameras, tie_points_colors);
-        phg::exportPointCloud(tie_points_and_cameras, std::string("/home/flint/s4/Photogrammetry/PhotogrammetryTasks2024/data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras.ply", tie_points_colors);
+        phg::exportPointCloud(tie_points_and_cameras, std::string("data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras.ply", tie_points_colors);
 
 #if ENABLE_BA
         runBA(tie_points, tracks, keypoints, cameras, ncameras, calib);
 #endif
         generateTiePointsCloud(tie_points, tracks, keypoints, imgs, aligned, cameras, ncameras, tie_points_and_cameras, tie_points_colors);
-        phg::exportPointCloud(tie_points_and_cameras, std::string("/home/flint/s4/Photogrammetry/PhotogrammetryTasks2024/data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras_ba.ply", tie_points_colors);
+        phg::exportPointCloud(tie_points_and_cameras, std::string("data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras_ba.ply", tie_points_colors);
     }
 
     // append remaining cameras one by one
@@ -362,7 +363,7 @@ TEST (SFM, ReconstructNViews) {
         std::vector<vector3d> tie_points_and_cameras;
         std::vector<cv::Vec3b> tie_points_colors;
         generateTiePointsCloud(tie_points, tracks, keypoints, imgs, aligned, cameras, ncameras, tie_points_and_cameras, tie_points_colors);
-        phg::exportPointCloud(tie_points_and_cameras, std::string("/home/flint/s4/Photogrammetry/PhotogrammetryTasks2024/data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras.ply", tie_points_colors);
+        phg::exportPointCloud(tie_points_and_cameras, std::string("data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras.ply", tie_points_colors);
 
         // Запуск Bundle Adjustment
 #if ENABLE_BA
@@ -370,7 +371,7 @@ TEST (SFM, ReconstructNViews) {
 #endif
 
         generateTiePointsCloud(tie_points, tracks, keypoints, imgs, aligned, cameras, ncameras, tie_points_and_cameras, tie_points_colors);
-        phg::exportPointCloud(tie_points_and_cameras, std::string("/home/flint/s4/Photogrammetry/PhotogrammetryTasks2024/data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras_ba.ply", tie_points_colors);
+        phg::exportPointCloud(tie_points_and_cameras, std::string("data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras_ba.ply", tie_points_colors);
     }
 }
 

--- a/tests/test_sfm_ba.cpp
+++ b/tests/test_sfm_ba.cpp
@@ -141,14 +141,14 @@ TEST (SFM, ReconstructNViews) {
     std::vector<cv::Mat> imgs;
     std::vector<std::string> imgs_labels;
     {
-        std::ifstream in(std::string("/home/flint/s4/Photogrammetry/PhotogrammetryTasks2024/data/src/datasets/") + DATASET_DIR + "/ordered_filenames.txt");
+        std::ifstream in(std::string("data/src/datasets/") + DATASET_DIR + "/ordered_filenames.txt");
         size_t nimages = 0;
         in >> nimages;
         std::cout << nimages << " images" << std::endl;
         for (int i = 0; i < nimages; ++i) {
             std::string img_name;
             in >> img_name;
-            std::string img_path = std::string("/home/flint/s4/Photogrammetry/PhotogrammetryTasks2024/data/src/datasets/") + DATASET_DIR + "/" + img_name;
+            std::string img_path = std::string("data/src/datasets/") + DATASET_DIR + "/" + img_name;
             cv::Mat img = cv::imread(img_path);
 
             if (img.empty()) {
@@ -285,13 +285,13 @@ TEST (SFM, ReconstructNViews) {
         std::vector<vector3d> tie_points_and_cameras;
         std::vector<cv::Vec3b> tie_points_colors;
         generateTiePointsCloud(tie_points, tracks, keypoints, imgs, aligned, cameras, ncameras, tie_points_and_cameras, tie_points_colors);
-        phg::exportPointCloud(tie_points_and_cameras, std::string("/home/flint/s4/Photogrammetry/PhotogrammetryTasks2024/data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras.ply", tie_points_colors);
+        phg::exportPointCloud(tie_points_and_cameras, std::string("data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras.ply", tie_points_colors);
 
 #if ENABLE_BA
         runBA(tie_points, tracks, keypoints, cameras, ncameras, calib);
 #endif
         generateTiePointsCloud(tie_points, tracks, keypoints, imgs, aligned, cameras, ncameras, tie_points_and_cameras, tie_points_colors);
-        phg::exportPointCloud(tie_points_and_cameras, std::string("/home/flint/s4/Photogrammetry/PhotogrammetryTasks2024/data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras_ba.ply", tie_points_colors);
+        phg::exportPointCloud(tie_points_and_cameras, std::string("data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras_ba.ply", tie_points_colors);
     }
 
     // append remaining cameras one by one
@@ -363,7 +363,7 @@ TEST (SFM, ReconstructNViews) {
         std::vector<vector3d> tie_points_and_cameras;
         std::vector<cv::Vec3b> tie_points_colors;
         generateTiePointsCloud(tie_points, tracks, keypoints, imgs, aligned, cameras, ncameras, tie_points_and_cameras, tie_points_colors);
-        phg::exportPointCloud(tie_points_and_cameras, std::string("/home/flint/s4/Photogrammetry/PhotogrammetryTasks2024/data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras.ply", tie_points_colors);
+        phg::exportPointCloud(tie_points_and_cameras, std::string("data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras.ply", tie_points_colors);
 
         // Запуск Bundle Adjustment
 #if ENABLE_BA
@@ -371,7 +371,7 @@ TEST (SFM, ReconstructNViews) {
 #endif
 
         generateTiePointsCloud(tie_points, tracks, keypoints, imgs, aligned, cameras, ncameras, tie_points_and_cameras, tie_points_colors);
-        phg::exportPointCloud(tie_points_and_cameras, std::string("/home/flint/s4/Photogrammetry/PhotogrammetryTasks2024/data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras_ba.ply", tie_points_colors);
+        phg::exportPointCloud(tie_points_and_cameras, std::string("data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras_ba.ply", tie_points_colors);
     }
 }
 


### PR DESCRIPTION
# Перечислите идеи и коротко обозначьте мысли которые у вас возникали по мере выполнения задания, в частности попробуйте ответить на вопросы:

1) test_ceres_solver/FitLine: почему найденная прямая и эталонная - не совпадают? Как это исправить пост-обработкой? Как это исправить формулировкой задачи?

Проблема в том, что коэффициенты можно домножить на константу и уравнение останется верным. На постобработке можно привести эталон и решение к одному масштабу. Можно поставить задачу по другому и зафиксировать значение одного из коэффициентов (однако у меня решение не находилось при таком подходе возможно я где-то набагал).

2) BA: представьте что вы написали преобразование phg::Calibration -> блок параметров и обратное блок параметров -> phg::Calibration. Как проверить простым образом что эти преобразования сделаны корректно? Что должно быть в логе про процент inliers до/после BA если runBA() вызывать всегда два раза пордяд? Иначе говоря - что следует из того что в идеале runBA() должна быть (мне очень нравится это слово) - [идемпотентна](https://ru.wikipedia.org/wiki/%D0%98%D0%B4%D0%B5%D0%BC%D0%BF%D0%BE%D1%82%D0%B5%D0%BD%D1%82%D0%BD%D0%BE%D1%81%D1%82%D1%8C)?

По идее при втором вызове BA мы процент inliers должен быть близок к 100, поскольку мы уже отфильтровали все выбросы и нашли с учетом этого решение задачи минимизации невязки, и при втором вызове должны остаться в том же решении

3) Какое максимальное число кадров у вас получилось хорошо выравнять для каждого из датасетов? (проверьте хотя бы saharov32 и herzjesu25) Не забудьте приложить скриншоты.

При NIMGS_LIMIT = 100 на обоих датасетах локально тесты прошли

4) Если бы вычисления в double были абсолютно точны - можно ли было бы назвать вычисления в Calibration::project/unproject строго зеркальными?

Так как мы в unproject не знаем изначальное значение r, мы не можем сделать преобразование зеркальным

5) Почему фокальная длина меняется от того что мы уменьшаем картинку? Почему именно f/downscale?

При downscale мы уменьшаем плоскость изображения в downscale раз, кажется, что для того чтобы модель камеры оставалась той же самой мы должны уменьшить фокальную длину в том же соотношении иначе область обзора камеры поменяется

6) Имеет ли право BA двигать точку отсчета системы координат (т.е. добавить константу ко всем координатам)? Как это повлияет на суммарную Loss?

Кажется имеет, поскольку наш лосс считается по невязке между проекцией 3д точки на плоскость камеры и распознанной ключевой точкой на фотографии, от сдвига на константу координаты проекции 3д точки не должны поменяться поскольку мы проецируем ее на плоскость камеры, координаты ключевой точки на фото тем более не должны поменяться. То есть лосс не изменится

7) Каким образом можно гарантировать чтобы при сравнении нескольких последовательно построенных облаков точек одного и того же датасета (созданных по мере добавления фотографии за фотографией) в MeshLab - облака не были хаотично смещены/отмасштабированы/повернуты друг от друга? 

Можно выравнивать координаты одинаковых камер, то есть когда мы знаем, что для одного облака i-я камера имела некоторые координаты мы можем выровнять i-ю камеру для следующего облака, поставив ее на тоже место.

100) Если есть - фидбек/идеи по улучшению задания.


<details><summary>Travis CI</summary><p>

<pre>
$ ./build/test_ceres_solver
...
$ ./build/test_sfm_ba
...
</pre>

</p></details>