### PR TITLE
Task06 Лев Сорвин МКН

### DIFF
--- a/src/phg/mvs/model_min_cut/min_cut_cgal_structs.cpp
+++ b/src/phg/mvs/model_min_cut/min_cut_cgal_structs.cpp
@@ -13,7 +13,7 @@ cgal_point_t to_cgal_point(vector3d p)
     return cgal_point_t(p[0], p[1], p[2]);
 }
 
-vertex_info_t::vertex_info_t(unsigned int camera_id, const cv::Vec3b &color, double radius) : color(color), radius(radius)
+vertex_info_t::vertex_info_t(unsigned int camera_id, const cv::Vec3b &color, double radius) : color(color), radius(radius), weight(1)
 {
     camera_ids.push_back(camera_id);
 }
@@ -38,4 +38,5 @@ void vertex_info_t::merge(const vertex_info_t &that)
     for (int i = 1; i < camera_ids.size(); ++i) {
         rassert(camera_ids[i - 1] < camera_ids[i], 23781274121024);
     }
+    weight += that.weight;
 }

--- a/src/phg/mvs/model_min_cut/min_cut_cgal_structs.cpp
+++ b/src/phg/mvs/model_min_cut/min_cut_cgal_structs.cpp
@@ -13,7 +13,7 @@ cgal_point_t to_cgal_point(vector3d p)
     return cgal_point_t(p[0], p[1], p[2]);
 }
 
-vertex_info_t::vertex_info_t(unsigned int camera_id, const cv::Vec3b &color) : color(color)
+vertex_info_t::vertex_info_t(unsigned int camera_id, const cv::Vec3b &color, double radius) : color(color), radius(radius)
 {
     camera_ids.push_back(camera_id);
 }

--- a/src/phg/mvs/model_min_cut/min_cut_cgal_structs.h
+++ b/src/phg/mvs/model_min_cut/min_cut_cgal_structs.h
@@ -13,8 +13,9 @@ struct vertex_info_t {
     cv::Vec3b                 color;
     size_t                    vertex_on_surface_id;
     double                    radius;
+    int                       weight;
 
-    vertex_info_t() : color(0, 0, 255) // red color, BGR convention (OpenCV compatible)
+    vertex_info_t() : color(0, 0, 255), weight(1) // red color, BGR convention (OpenCV compatible)
     {}
 
     vertex_info_t(unsigned int camera_id, const cv::Vec3b &color, double radius);

--- a/src/phg/mvs/model_min_cut/min_cut_cgal_structs.h
+++ b/src/phg/mvs/model_min_cut/min_cut_cgal_structs.h
@@ -12,11 +12,12 @@ struct vertex_info_t {
     std::vector<unsigned int> camera_ids;
     cv::Vec3b                 color;
     size_t                    vertex_on_surface_id;
+    double                    radius;
 
     vertex_info_t() : color(0, 0, 255) // red color, BGR convention (OpenCV compatible)
     {}
 
-    vertex_info_t(unsigned int camera_id, const cv::Vec3b &color);
+    vertex_info_t(unsigned int camera_id, const cv::Vec3b &color, double radius);
 
     void merge(const vertex_info_t &that);
 };

--- a/src/phg/mvs/model_min_cut/min_cut_defines.h
+++ b/src/phg/mvs/model_min_cut/min_cut_defines.h
@@ -1,4 +1,4 @@
-#define MERGE_THRESHOLD_RADIUS_KOEF     0.1
+#define MERGE_THRESHOLD_RADIUS_KOEF     10.0
 
 #define LAMBDA_OUT                      1.0
 #define LAMBDA_IN                       1.0

--- a/src/phg/mvs/model_min_cut/min_cut_model_builder.cpp
+++ b/src/phg/mvs/model_min_cut/min_cut_model_builder.cpp
@@ -344,7 +344,13 @@ void MinCutModelBuilder::buildMesh(std::vector<cv::Vec3i> &mesh_faces, std::vect
     timer rays_traversing_t;
     double avg_triangles_intersected_per_ray = 0;
     size_t nrays = 0;
-    for (auto vi = proxy->triangulation.all_vertices_begin(); vi != proxy->triangulation.all_vertices_end(); ++vi) {
+    std::vector<vertex_handle_t> vertices;
+    for (auto vi = proxy->triangulation.all_vertices_begin(); vi != proxy->triangulation.all_vertices_end(); ++vi)
+    {
+        vertices.push_back(vi);
+    }
+    for (int i = 0; i < vertices.size(); ++i) {
+        auto vi = vertices[i];
         if (vi->info().camera_ids.size() == 0) {
             // TODO 2004 подумайте и напишите тут какие вершины бывают без камер вообще? почему мы их пропускаем? что и почему случится если убрать это пропускание?
             continue;
@@ -353,7 +359,6 @@ void MinCutModelBuilder::buildMesh(std::vector<cv::Vec3i> &mesh_faces, std::vect
         const vector3d point0 = from_cgal_point(vi->point());
         const std::vector<cgal_facet_t> facets_around_point0 = fetchVertexBoundingFacets(proxy->triangulation, vi);
 
-#pragma omp parallel for
         for (unsigned int ci = 0; ci < vi->info().camera_ids.size(); ++ci) {
             // для каждой вершины триангуляции point0 и каждой камеры к которой эта точка имеет отношение (т.е. содержится где-то в карте глубины)
 

--- a/src/phg/sfm/ematrix.cpp
+++ b/src/phg/sfm/ematrix.cpp
@@ -205,7 +205,8 @@ void phg::decomposeUndistortedPMatrix(cv::Matx33d &R, cv::Vec3d &O, const cv::Ma
     O(2) = O_mat(2);
 
     if (cv::determinant(R) < 0) {
-        R *= -1;   
+        R *= -1;
+        O *= -1;
     }
 }
 

--- a/src/phg/utils/point_cloud_export.cpp
+++ b/src/phg/utils/point_cloud_export.cpp
@@ -11,7 +11,7 @@
 #include "opencv2/core/core.hpp"
 #include <fstream>
 #include <iomanip>
-
+#include <filesystem>
 
 namespace {
 
@@ -227,6 +227,7 @@ void phg::exportPointCloud(const std::vector<cv::Vec3d> &point_cloud, const std:
         } 
     }
 
+    std::filesystem::create_directories(std::filesystem::path { path }.parent_path());
     DataExporter data(coords3d, img, path, FileFormat::PLY_BIN_BIGEND);
     if (!point_cloud_normal.empty()) {
         data.normals = normals;


### PR DESCRIPTION
# Перечислите идеи и коротко обозначьте мысли которые у вас возникали по мере выполнения задания (так же комментарии и мысли прямо в коде пишите по мере выполнения задания)

- [x] **TODO 1001** запустите test_mesh_min_cut/DepthMapsToPointClouds и убедитесь что облака точек построенные по картам глубины выглядят правдоподобно

- [x] **TODO 1002** запустите test_mesh_min_cut/FromAllDepthMaps и убедитесь что полигональные модели построенные по картам глубины выглядят правдоподобно и например для DATASET_DIR=saharov32, DATASET_DOWNSCALE=4, CAMERAS_LIMIT=5 выглядит похоже на это:

- [x] **TODO 2001** appendToTriangulation(): реализуйте нормальную проверку объединять ли точку с уже добавленной ранее (с учетом r и MERGE_THRESHOLD_RADIUS_KOEF)

- [x] **TODO 2002** добавьте проверку - не опирается ли треугольник на одну из фиктивных вершин (лежащих на гранях вспомогательного bounding box), можете для этого использовать bb_min и bb_max, или добавьте явный флаг в каждую вершину
![image](https://github.com/PhotogrammetryCourse/PhotogrammetryTasks2024/assets/64495509/df0f30dc-65c5-440e-a62f-856e85663fbe)


- [x] **TODO 2003** некоторые треугольники выглядят темными в результирующей модели, проблема уходит если выключить в MeshLab освещение (кнопка желтой лампочка - Light on/off) которое учитывает нормаль, которая строится с учетом порядка вершин треугольника (по часовой стрелке или против)
![image](https://github.com/PhotogrammetryCourse/PhotogrammetryTasks2024/assets/64495509/16bb4d70-ee04-4d24-b85f-efe75e41d0f1)


- [x] **TODO 2004** подумайте и напишите тут какие вершины бывают без камер вообще? почему мы их пропускаем? что и почему случится если убрать это пропускание?

Без камер бывают бесконечно удаленные вершины или вершины на aabb всей сцены. Мы их пропускаем, потому что это не настоящие вершины. Если убрать это пропускание, мы добавим ложные веса на лучах в эти вершины.

- [x] **TODO 2005** изменится ли что-то если сильно увеличить пропускные способности ребер от истока? (т.е. сделать пропускную способность из истока равной бесконечности?)
Я существенной разницы не заметил, в репозитории бесконечность и оставил

- [x] **TODO 3001** сделайте пропускные способности на ребрах не единичными а затухающими тем сильнее чем ближе к поверхности
Затухает экспоненциально, как и сказано в статье

- [x] **TODO 3002** сделайте соединение со стоком в ячейке не сразу за вершиной, а на небольшом углублении (пропорционально размеру точки)

После реализации labadut2009 (не замечено существенной разницы):
![image](https://github.com/PhotogrammetryCourse/PhotogrammetryTasks2024/assets/64495509/f93616a9-d2cf-4b69-b445-ba1d70123efc)


- [ ] **TODO 3500** Weak support: реализуйте идею из [jancosek2011 - Multi-View Reconstruction Preserving Weakly-Supported Surfaces](https://compsciclub.ru/attachments/classes/file_XyLpDjLx/jancosek2011.pdf)

Это не  сделано, так как не понял, как. Надо это делать вдоль каждого луча после первого обхода, где все веса на ребрах высчитались?

- [x] **TODO 4001** подвиньте вершины в среднюю координату среди всех точек которые в ней зачлись

- [x] **TODO 4002** поэкспериментируйте со значением MERGE_THRESHOLD_RADIUS_KOEF, есть ли интересности? какое значение вы бы предложили использовать в условной финальной версии?
Его точно нужно сделать побольше (камень внизу статуи выглядит ощутимо лучше с увеличением threshold) но при большом threshold (где-то начиная со 100) статуя начинает плыть. Я оставил значение 10.

- [x] **TODO 4003** добавьте усреднение цветов среди всех склеившихся вершин, приложите скриншот с/без усреднения

![image](https://github.com/PhotogrammetryCourse/PhotogrammetryTasks2024/assets/64495509/29ac622f-9554-434f-91bc-5ac1ee9e2c80)
Чуть меньше выбросов (белых точек) на стенах и статуе, но не прямо существенно, как мне кажется

- [x] **TODO 5001** как в целом можно ускорить реализацию? есть ли идеи? попробуйте это сделать (и запишите какого ускорения получилось добиться, а так же изменился ли результат)
В целом ускорение в моем понимании сводится к пунктам ниже. Алгоритм по своей сути -- это трассировка лучей в точки и распределение весов на этих лучах. Лучи независимые и их можно обрабатывать параллельно, а вот внутри луча параллельность уже плохо работает, т.к. алгоритм пересечения луча с сеткой очень не параллеллится в текущем виде (но при этом у него линейная асимптотика, сильно лучше как будто бы не сделаешь). Шансы есть добавить параллельность, но это как будто бы не очень нужно --- параллельность на лучах это уже не плохо.
Вопрос в том, что можно улучшить внутри вычисления на луче. На луче мы пересекаем последовательно сетку и считаем веса. На самом деле при пересечении треугольника с лучом можно одновременно посчитать и расстояние до пересечения (Если сказать, что $O + D \cdot t = A + (B - A) u + (C-A) v$, то получится система линейных уравнений на $u$, $v$, $t$, в которой $d \cdot |D|$ -- это в точности ориентированное расстояние до плоскости), но это вряд ли узкое место (с оптимизациями плюсов решение системы из трех линейных уравнений должно занимать совсем мало времени), так что я не пытался это исправить. При этом сэкономить существенно на примерном решении скорее всего тоже не получится -- это и так линейная система уравнений.

- [x] **TODO 5002** а не рапараллелить ли? если будете распараллеливать - убедитесь что вы заменили triangulation.incident_cells() на triangulation.incident_cells_threadsafe()

- [x] **TODO 5003** не слишком ли часто вызывается triangulation.locate()? может оно тормозит? (поиск ячейки содержащей заданную точку)

Да, слишком часто. Я добавил кэширование и трассировка лучей стала в два раза быстрее.

- [x] **TODO 5004** CGAL::do_intersect() проверяет луч и треугольник на пересечение абсолютно точно, и это надежно, но медленно. А что если мы грубо будем проверять пересечения (самописным простым кодом на float-ах)? А когда пересечение не факт что произошло - ну что же, пусть этому лучу не повезло, будем надеяться это не сильно изменит результат? Попробуйте и сравните скорость и результат.

См. TODO 5001
