### PR TITLE
Task04 Ilia Nechaev МКН

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,12 @@
 build
 cmake-build*
 data/src/test_sfm/saharov/*.JPG
+2.0.0.zip
+ceres-solver-2.0.0
+Makefile
+**/CMakeCache.txt
+**/cmake_install.cmake
+**/CMakeFiles
+**/CTestTestfile.cmake
+data
+

--- a/src/phg/core/calibration.cpp
+++ b/src/phg/core/calibration.cpp
@@ -37,6 +37,9 @@ cv::Vec3d phg::Calibration::project(const cv::Vec3d &point) const
 
     // TODO 11: добавьте учет радиальных искажений (k1_, k2_) (после деления на Z, но до умножения на f)
 
+    double r = x * x + y * y;
+    x += k1_ * r + k2_ * r * r;
+    y +=  k1_ * r + k2_ * r * r;
 
     x *= f_;
     y *= f_;
@@ -56,6 +59,10 @@ cv::Vec3d phg::Calibration::unproject(const cv::Vec2d &pixel) const
     y /= f_;
 
     // TODO 12: добавьте учет радиальных искажений, когда реализуете - подумайте: почему строго говоря это - не симметричная формула формуле из project? (но лишь приближение)
+
+    double r = x * x + y * y;
+    x -= k1_ * r + k2_ * r * r;
+    y -=  k1_ * r + k2_ * r * r;
 
     return cv::Vec3d(x, y, 1.0);
 }

--- a/tests/test_sfm_ba.cpp
+++ b/tests/test_sfm_ba.cpp
@@ -22,7 +22,7 @@
 #include <ceres/ceres.h>
 
 // TODO включите Bundle Adjustment (но из любопытства посмотрите как ведет себя реконструкция без BA например для saharov32 без BA)
-#define ENABLE_BA                             0
+#define ENABLE_BA                             1
 
 // TODO когда заработает при малом количестве фотографий - увеличьте это ограничение до 100 чтобы попробовать обработать все фотографии (если же успешно будут отрабаывать только N фотографий - отправьте PR выставив здесь это N)
 #define NIMGS_LIMIT                           10 // сколько фотографий обрабатывать (можно выставить меньше чтобы ускорить экспериментирование, или в случае если весь датасет не выравнивается)
@@ -71,9 +71,11 @@
 //________________________________________________________________________________
 
 
-namespace {
+namespace
+{
 
-    vector3d relativeOrientationAngles(const matrix3d &R0, const vector3d &O0, const matrix3d &R1, const vector3d &O1) {
+    vector3d relativeOrientationAngles(const matrix3d &R0, const vector3d &O0, const matrix3d &R1, const vector3d &O1)
+    {
         vector3d a = R0 * vector3d{0, 0, 1};
         vector3d b = O0 - O1;
         vector3d c = R1 * vector3d{0, 0, 1};
@@ -82,7 +84,8 @@ namespace {
         double normb = cv::norm(b);
         double normc = cv::norm(c);
 
-        if (norma == 0 || normb == 0 || normc == 0) {
+        if (norma == 0 || normb == 0 || normc == 0)
+        {
             throw std::runtime_error("norma == 0 || normb == 0 || normc == 0");
         }
 
@@ -100,7 +103,8 @@ namespace {
     }
 
     // one track corresponds to one 3d point
-    class Track {
+    class Track
+    {
     public:
         Track()
         {
@@ -108,321 +112,497 @@ namespace {
         }
 
         bool disabled;
-        std::vector<std::pair<int, int>> img_kpt_pairs;
+        std::vector <std::pair<int, int>> img_kpt_pairs;
     };
 
 }
 
-void generateTiePointsCloud(const std::vector<vector3d> &tie_points,
-                            const std::vector<Track> &tracks,
-                            const std::vector<std::vector<cv::KeyPoint>> &keypoints,
-                            const std::vector<cv::Mat> &imgs,
+void generateTiePointsCloud(const std::vector <vector3d> &tie_points,
+                            const std::vector <Track> &tracks,
+                            const std::vector <std::vector<cv::KeyPoint>> &keypoints,
+                            const std::vector <cv::Mat> &imgs,
                             const std::vector<char> &aligned,
-                            const std::vector<matrix34d> &cameras,
+                            const std::vector <matrix34d> &cameras,
                             int ncameras,
-                            std::vector<vector3d> &tie_points_and_cameras,
-                            std::vector<cv::Vec3b> &tie_points_colors);
+                            std::vector <vector3d> &tie_points_and_cameras,
+                            std::vector <cv::Vec3b> &tie_points_colors);
 
-void runBA(std::vector<vector3d> &tie_points,
-           std::vector<Track> &tracks,
-           std::vector<std::vector<cv::KeyPoint>> &keypoints,
-           std::vector<matrix34d> &cameras,
+void runBA(std::vector <vector3d> &tie_points,
+           std::vector <Track> &tracks,
+           std::vector <std::vector<cv::KeyPoint>> &keypoints,
+           std::vector <matrix34d> &cameras,
            int ncameras,
            phg::Calibration &calib,
-           bool verbose=false);
+           bool verbose = false);
 
-TEST (SFM, ReconstructNViews) {
-    using namespace cv;
+TEST (SFM, ReconstructNViews
+) {
+using namespace cv;
 
-    // Чтобы было проще - картинки упорядочены заранее в файле data/src/datasets/DATASETNAME/ordered_filenames.txt
-    std::vector<cv::Mat> imgs;
-    std::vector<std::string> imgs_labels;
-    {
-        std::ifstream in(std::string("data/src/datasets/") + DATASET_DIR + "/ordered_filenames.txt");
-        size_t nimages = 0;
-        in >> nimages;
-        std::cout << nimages << " images" << std::endl;
-        for (int i = 0; i < nimages; ++i) {
-            std::string img_name;
-            in >> img_name;
-            std::string img_path = std::string("data/src/datasets/") + DATASET_DIR + "/" + img_name;
-            cv::Mat img = cv::imread(img_path);
+// Чтобы было проще - картинки упорядочены заранее в файле data/src/datasets/DATASETNAME/ordered_filenames.txt
+std::vector <cv::Mat> imgs;
+std::vector <std::string> imgs_labels;
+{
+std::ifstream in(std::string("data/src/datasets/") + DATASET_DIR + "/ordered_filenames.txt");
+size_t nimages = 0;
+in >>
+nimages;
+std::cout << nimages << " images" <<
+std::endl;
+for (
+int i = 0;
+i<nimages;
+++i) {
+std::string img_name;
+in >>
+img_name;
+std::string img_path = std::string("data/src/datasets/") + DATASET_DIR + "/" + img_name;
+cv::Mat img = cv::imread(img_path);
 
-            if (img.empty()) {
-                throw std::runtime_error("Can't read image: " + to_string(img_path));
-            }
+if (img.
 
-            // выполняем уменьшение картинки если оригинальные картинки в этом датасете - слишком большие для используемой реализации SIFT
-            int downscale = DATASET_DOWNSCALE;
-            while (downscale > 1) {
-                cv::pyrDown(img, img);
-                rassert(downscale % 2 == 0, 1249219412940115);
-                downscale /= 2;
-            }
+empty()
 
-            imgs.push_back(img);
-            imgs_labels.push_back(img_name);
-        }
-    }
-
-    phg::Calibration calib(imgs[0].cols, imgs[0].rows);
-    calib.f_ = DATASET_F;
-
-    // сверяем что все картинки одинакового размера (мы ведь предполагаем что их снимала одна и та же камера с одними и те же интринсиками)
-    for (const auto &img : imgs) {
-        rassert(img.cols == imgs[0].cols && img.rows == imgs[0].rows, 34125412512512);
-    }
-
-    const size_t n_imgs = std::min(imgs.size(), (size_t) NIMGS_LIMIT);
-
-    std::cout << "detecting points..." << std::endl;
-    std::vector<std::vector<cv::KeyPoint>> keypoints(n_imgs);
-    std::vector<std::vector<int>> track_ids(n_imgs);
-    std::vector<cv::Mat> descriptors(n_imgs);
-    cv::Ptr<cv::FeatureDetector> detector = cv::SIFT::create();
-    for (int i = 0; i < (int) n_imgs; ++i) {
-        detector->detectAndCompute(imgs[i], cv::noArray(), keypoints[i], descriptors[i]);
-        track_ids[i].resize(keypoints[i].size(), -1);
-    }
-
-    std::cout << "matching points..." << std::endl;
-    using Matches = std::vector<cv::DMatch>;
-    std::vector<std::vector<Matches>> matches(n_imgs);
-    size_t ndone = 0;
-    #pragma omp parallel for
-    for (int i = 0; i < n_imgs; ++i) {
-        matches[i].resize(n_imgs);
-        for (int j = 0; j < n_imgs; ++j) {
-            if (i == j) {
-                continue;
-            }
-
-            // Flann matching
-            std::vector<std::vector<DMatch>> knn_matches;
-            Ptr<DescriptorMatcher> matcher = DescriptorMatcher::create(DescriptorMatcher::FLANNBASED);
-            matcher->knnMatch( descriptors[i], descriptors[j], knn_matches, 2 );
-            std::vector<DMatch> good_matches(knn_matches.size());
-            for (int k = 0; k < (int) knn_matches.size(); ++k) {
-                good_matches[k] = knn_matches[k][0];
-            }
-
-            // Filtering matches GMS
-            std::vector<DMatch> good_matches_gms;
-            int inliers = phg::filterMatchesGMS(good_matches, keypoints[i], keypoints[j], imgs[i].size(), imgs[j].size(), good_matches_gms, false);
-            #pragma omp critical
-            {
-                ++ndone;
-                if (inliers > 0) {
-                    std::cout << to_percent(ndone, n_imgs * (n_imgs - 1)) + "% - Cameras " << i << "-" << j << " (" << imgs_labels[i] << "-" << imgs_labels[j] << "): " << inliers << " matches" << std::endl;
-                }
-            }
-
-            matches[i][j] = good_matches_gms;
-        }
-    }
-
-    std::vector<Track> tracks;
-    std::vector<vector3d> tie_points;
-    std::vector<matrix34d> cameras(n_imgs);
-    std::vector<char> aligned(n_imgs);
-
-    // align first two cameras
-    {
-        std::cout << "Initial alignment from cameras #0 and #1 (" << imgs_labels[0] << ", " << imgs_labels[1] << ")" << std::endl;
-        // matches from first to second image in specified sequence
-        const Matches &good_matches_gms = matches[0][1];
-        const std::vector<cv::KeyPoint> &keypoints0 = keypoints[0];
-        const std::vector<cv::KeyPoint> &keypoints1 = keypoints[1];
-        const phg::Calibration &calib0 = calib;
-        const phg::Calibration &calib1 = calib;
-
-        std::vector<cv::Vec2d> points0, points1;
-        for (const cv::DMatch &match : good_matches_gms) {
-            cv::Vec2f pt1 = keypoints0[match.queryIdx].pt;
-            cv::Vec2f pt2 = keypoints1[match.trainIdx].pt;
-            points0.push_back(pt1);
-            points1.push_back(pt2);
-        }
-
-        matrix3d F = phg::findFMatrix(points0, points1, 3, false);
-        matrix3d E = phg::fmatrix2ematrix(F, calib0, calib1);
-
-        matrix34d P0, P1;
-        phg::decomposeEMatrix(P0, P1, E, points0, points1, calib0, calib1, false);
-
-        cameras[0] = P0;
-        cameras[1] = P1;
-        aligned[0] = true;
-        aligned[1] = true;
-
-        matrix34d Ps[2] = {P0, P1};
-        for (int i = 0; i < (int) good_matches_gms.size(); ++i) {
-            vector3d ms[2] = {calib0.unproject(points0[i]), calib1.unproject(points1[i])};
-            vector4d X = phg::triangulatePoint(Ps, ms, 2);
-
-            if (X(3) == 0) {
-                std::cerr << "infinite point" << std::endl;
-                continue;
-            }
-
-            vector3d X3d{X(0) / X(3), X(1) / X(3), X(2) / X(3)};
-
-            tie_points.push_back(X3d);
-
-            Track track;
-            track.img_kpt_pairs.push_back({0, good_matches_gms[i].queryIdx});
-            track.img_kpt_pairs.push_back({1, good_matches_gms[i].trainIdx});
-            track_ids[0][good_matches_gms[i].queryIdx] = tracks.size();
-            track_ids[1][good_matches_gms[i].trainIdx] = tracks.size();
-            tracks.push_back(track);
-        }
-
-        int ncameras = 2;
-
-        std::vector<vector3d> tie_points_and_cameras;
-        std::vector<cv::Vec3b> tie_points_colors;
-        generateTiePointsCloud(tie_points, tracks, keypoints, imgs, aligned, cameras, ncameras, tie_points_and_cameras, tie_points_colors);
-        phg::exportPointCloud(tie_points_and_cameras, std::string("data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras.ply", tie_points_colors);
-
-#if ENABLE_BA
-        runBA(tie_points, tracks, keypoints, cameras, ncameras, calib);
-#endif
-        generateTiePointsCloud(tie_points, tracks, keypoints, imgs, aligned, cameras, ncameras, tie_points_and_cameras, tie_points_colors);
-        phg::exportPointCloud(tie_points_and_cameras, std::string("data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras_ba.ply", tie_points_colors);
-    }
-
-    // append remaining cameras one by one
-    for (int i_camera = 2; i_camera < n_imgs; ++i_camera) {
-
-        const std::vector<cv::KeyPoint> &keypoints0 = keypoints[i_camera];
-        const phg::Calibration &calib0 = calib;
-
-        std::vector<vector3d> Xs;
-        std::vector<vector2d> xs;
-        for (int i_camera_prev = 0; i_camera_prev < i_camera; ++i_camera_prev) {
-            const Matches &good_matches_gms = matches[i_camera][i_camera_prev];
-            for (const cv::DMatch &match : good_matches_gms) {
-                int track_id = track_ids[i_camera_prev][match.trainIdx];
-                if (track_id != -1) {
-                    if (tracks[track_id].disabled)
-                        continue; // пропускаем выключенные точки (признанные выбросами)
-                    Xs.push_back(tie_points[track_id]);
-                    cv::Vec2f pt = keypoints0[match.queryIdx].pt;
-                    xs.push_back(pt);
-                }
-            }
-        }
-
-        std::cout << "Append camera #" << i_camera << " (" << imgs_labels[i_camera] << ") to alignment via " << Xs.size() << " common points" << std::endl;
-        rassert(Xs.size() > 0, 2318254129859128305);
-        matrix34d P = phg::findCameraMatrix(calib0, Xs, xs, false);
-
-        cameras[i_camera] = P;
-        aligned[i_camera] = true;
-
-        for (int i_camera_prev = 0; i_camera_prev < i_camera; ++i_camera_prev) {
-            const std::vector<cv::KeyPoint> &keypoints1 = keypoints[i_camera_prev];
-            const phg::Calibration &calib1 = calib;
-            const Matches &good_matches_gms = matches[i_camera][i_camera_prev];
-            for (const cv::DMatch &match : good_matches_gms) {
-                int track_id = track_ids[i_camera_prev][match.trainIdx];
-                if (track_id == -1) {
-                    matrix34d Ps[2] = {P, cameras[i_camera_prev]};
-                    cv::Vec2f pts[2] = {keypoints0[match.queryIdx].pt, keypoints1[match.trainIdx].pt};
-                    vector3d ms[2] = {calib0.unproject(pts[0]), calib1.unproject(pts[1])};
-                    vector4d X = phg::triangulatePoint(Ps, ms, 2);
-
-                    if (X(3) == 0) {
-                        std::cerr << "infinite point" << std::endl;
-                        continue;
-                    }
-
-                    tie_points.push_back({X(0) / X(3), X(1) / X(3), X(2) / X(3)});
-
-                    Track track;
-                    track.img_kpt_pairs.push_back({i_camera, match.queryIdx});
-                    track.img_kpt_pairs.push_back({i_camera_prev, match.trainIdx});
-                    track_ids[i_camera][match.queryIdx] = tracks.size();
-                    track_ids[i_camera_prev][match.trainIdx] = tracks.size();
-                    tracks.push_back(track);
-                } else {
-                    if (tracks[track_id].disabled)
-                        continue; // пропускаем выключенные точки (признанные выбросами)
-                    Track &track = tracks[track_id];
-                    track.img_kpt_pairs.push_back({i_camera, match.queryIdx});
-                    track_ids[i_camera][match.queryIdx] = track_id;
-                }
-            }
-        }
-
-        int ncameras = i_camera + 1;
-
-        std::vector<vector3d> tie_points_and_cameras;
-        std::vector<cv::Vec3b> tie_points_colors;
-        generateTiePointsCloud(tie_points, tracks, keypoints, imgs, aligned, cameras, ncameras, tie_points_and_cameras, tie_points_colors);
-        phg::exportPointCloud(tie_points_and_cameras, std::string("data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras.ply", tie_points_colors);
-
-        // Запуск Bundle Adjustment
-#if ENABLE_BA
-        runBA(tie_points, tracks, keypoints, cameras, ncameras, calib);
-#endif
-
-        generateTiePointsCloud(tie_points, tracks, keypoints, imgs, aligned, cameras, ncameras, tie_points_and_cameras, tie_points_colors);
-        phg::exportPointCloud(tie_points_and_cameras, std::string("data/debug/test_sfm_ba/") + DATASET_DIR + "/point_cloud_" + to_string(ncameras) + "_cameras_ba.ply", tie_points_colors);
-    }
+) {
+throw std::runtime_error("Can't read image: " +
+to_string(img_path)
+);
 }
 
-class ReprojectionError {
+// выполняем уменьшение картинки если оригинальные картинки в этом датасете - слишком большие для используемой реализации SIFT
+int downscale = DATASET_DOWNSCALE;
+while (downscale > 1) {
+cv::pyrDown(img, img
+);
+rassert(downscale
+% 2 == 0, 1249219412940115);
+downscale /= 2;
+}
+
+imgs.
+push_back(img);
+imgs_labels.
+push_back(img_name);
+}
+}
+
+phg::Calibration calib(imgs[0].cols, imgs[0].rows);
+calib.
+f_ = DATASET_F;
+
+// сверяем что все картинки одинакового размера (мы ведь предполагаем что их снимала одна и та же камера с одними и те же интринсиками)
+for (
+const auto &img
+: imgs) {
+rassert(img
+.cols == imgs[0].
+cols &&img
+.rows == imgs[0].rows, 34125412512512);
+}
+
+const size_t n_imgs = std::min(imgs.size(), (size_t) NIMGS_LIMIT);
+
+std::cout << "detecting points..." <<
+std::endl;
+std::vector <std::vector<cv::KeyPoint>> keypoints(n_imgs);
+std::vector <std::vector<int>> track_ids(n_imgs);
+std::vector <cv::Mat> descriptors(n_imgs);
+cv::Ptr <cv::FeatureDetector> detector = cv::SIFT::create();
+for (
+int i = 0;
+
+i<(int)
+
+n_imgs;
+++i) {
+detector->
+detectAndCompute(imgs[i], cv::noArray(), keypoints[i], descriptors[i]
+);
+track_ids[i].
+resize(keypoints[i]
+.
+
+size(),
+
+-1);
+}
+
+std::cout << "matching points..." <<
+std::endl;
+using Matches = std::vector<cv::DMatch>;
+std::vector <std::vector<Matches>> matches(n_imgs);
+size_t ndone = 0;
+#pragma omp parallel for
+for (
+int i = 0;
+i<n_imgs;
+++i) {
+matches[i].
+resize(n_imgs);
+for (
+int j = 0;
+j<n_imgs;
+++j) {
+if (i == j) {
+continue;
+}
+
+// Flann matching
+std::vector <std::vector<DMatch>> knn_matches;
+Ptr <DescriptorMatcher> matcher = DescriptorMatcher::create(DescriptorMatcher::FLANNBASED);
+matcher->
+knnMatch( descriptors[i], descriptors[j], knn_matches,
+2 );
+std::vector <DMatch> good_matches(knn_matches.size());
+for (
+int k = 0;
+
+k<(int)
+
+knn_matches.
+
+size();
+
+++k) {
+good_matches[k] = knn_matches[k][0];
+}
+
+// Filtering matches GMS
+std::vector <DMatch> good_matches_gms;
+int inliers = phg::filterMatchesGMS(good_matches, keypoints[i], keypoints[j], imgs[i].size(), imgs[j].size(),
+                                    good_matches_gms, false);
+#pragma omp critical
+{
+++
+ndone;
+if (inliers > 0) {
+std::cout <<
+to_percent(ndone, n_imgs
+* (n_imgs - 1)) + "% - Cameras " << i << "-" << j << " (" << imgs_labels[i] << "-" << imgs_labels[j] << "): " << inliers << " matches" <<
+std::endl;
+}
+}
+
+matches[i][j] =
+good_matches_gms;
+}
+}
+
+std::vector <Track> tracks;
+std::vector <vector3d> tie_points;
+std::vector <matrix34d> cameras(n_imgs);
+std::vector<char> aligned(n_imgs);
+
+// align first two cameras
+{
+std::cout << "Initial alignment from cameras #0 and #1 (" << imgs_labels[0] << ", " << imgs_labels[1] << ")" <<
+std::endl;
+// matches from first to second image in specified sequence
+const Matches &good_matches_gms = matches[0][1];
+const std::vector <cv::KeyPoint> &keypoints0 = keypoints[0];
+const std::vector <cv::KeyPoint> &keypoints1 = keypoints[1];
+const phg::Calibration &calib0 = calib;
+const phg::Calibration &calib1 = calib;
+
+std::vector <cv::Vec2d> points0, points1;
+for (
+const cv::DMatch &match
+: good_matches_gms) {
+cv::Vec2f pt1 = keypoints0[match.queryIdx].pt;
+cv::Vec2f pt2 = keypoints1[match.trainIdx].pt;
+points0.
+push_back(pt1);
+points1.
+push_back(pt2);
+}
+
+matrix3d F = phg::findFMatrix(points0, points1, 3, false);
+matrix3d E = phg::fmatrix2ematrix(F, calib0, calib1);
+
+matrix34d P0, P1;
+phg::decomposeEMatrix(P0, P1, E, points0, points1, calib0, calib1,
+false);
+
+cameras[0] =
+P0;
+cameras[1] =
+P1;
+aligned[0] = true;
+aligned[1] = true;
+
+matrix34d Ps[2] = {P0, P1};
+for (
+int i = 0;
+
+i<(int)
+
+good_matches_gms.
+
+size();
+
+++i) {
+vector3d ms[2] = {calib0.unproject(points0[i]), calib1.unproject(points1[i])};
+vector4d X = phg::triangulatePoint(Ps, ms, 2);
+
+if (X(3) == 0) {
+std::cerr << "infinite point" <<
+std::endl;
+continue;
+}
+
+vector3d X3d{X(0) / X(3), X(1) / X(3), X(2) / X(3)};
+
+tie_points.
+push_back(X3d);
+
+Track track;
+track.img_kpt_pairs.push_back({
+0, good_matches_gms[i].queryIdx});
+track.img_kpt_pairs.push_back({
+1, good_matches_gms[i].trainIdx});
+track_ids[0][good_matches_gms[i].queryIdx] = tracks.
+
+size();
+
+track_ids[1][good_matches_gms[i].trainIdx] = tracks.
+
+size();
+
+tracks.
+push_back(track);
+}
+
+int ncameras = 2;
+
+std::vector <vector3d> tie_points_and_cameras;
+std::vector <cv::Vec3b> tie_points_colors;
+generateTiePointsCloud(tie_points, tracks, keypoints, imgs, aligned, cameras, ncameras, tie_points_and_cameras, tie_points_colors
+);
+phg::exportPointCloud(tie_points_and_cameras, std::string("data/debug/test_sfm_ba/")
++ DATASET_DIR + "/point_cloud_" +
+to_string(ncameras)
++ "_cameras.ply", tie_points_colors);
+
+#if ENABLE_BA
+runBA(tie_points, tracks, keypoints, cameras, ncameras, calib
+);
+#endif
+generateTiePointsCloud(tie_points, tracks, keypoints, imgs, aligned, cameras, ncameras, tie_points_and_cameras, tie_points_colors
+);
+phg::exportPointCloud(tie_points_and_cameras, std::string("data/debug/test_sfm_ba/")
++ DATASET_DIR + "/point_cloud_" +
+to_string(ncameras)
++ "_cameras_ba.ply", tie_points_colors);
+}
+
+// append remaining cameras one by one
+for (
+int i_camera = 2;
+i_camera<n_imgs;
+++i_camera) {
+
+const std::vector <cv::KeyPoint> &keypoints0 = keypoints[i_camera];
+const phg::Calibration &calib0 = calib;
+
+std::vector <vector3d> Xs;
+std::vector <vector2d> xs;
+for (
+int i_camera_prev = 0;
+i_camera_prev<i_camera;
+++i_camera_prev) {
+const Matches &good_matches_gms = matches[i_camera][i_camera_prev];
+for (
+const cv::DMatch &match
+: good_matches_gms) {
+int track_id = track_ids[i_camera_prev][match.trainIdx];
+if (track_id != -1) {
+if (tracks[track_id].disabled)
+continue; // пропускаем выключенные точки (признанные выбросами)
+Xs.
+push_back(tie_points[track_id]);
+cv::Vec2f pt = keypoints0[match.queryIdx].pt;
+xs.
+push_back(pt);
+}
+}
+}
+
+std::cout << "Append camera #" << i_camera << " (" << imgs_labels[i_camera] << ") to alignment via " << Xs.
+
+size()
+
+<< " common points" <<
+std::endl;
+rassert(Xs
+.
+
+size()
+
+> 0, 2318254129859128305);
+matrix34d P = phg::findCameraMatrix(calib0, Xs, xs, false);
+
+cameras[i_camera] =
+P;
+aligned[i_camera] = true;
+
+for (
+int i_camera_prev = 0;
+i_camera_prev<i_camera;
+++i_camera_prev) {
+const std::vector <cv::KeyPoint> &keypoints1 = keypoints[i_camera_prev];
+const phg::Calibration &calib1 = calib;
+const Matches &good_matches_gms = matches[i_camera][i_camera_prev];
+for (
+const cv::DMatch &match
+: good_matches_gms) {
+int track_id = track_ids[i_camera_prev][match.trainIdx];
+if (track_id == -1) {
+matrix34d Ps[2] = {P, cameras[i_camera_prev]};
+cv::Vec2f pts[2] = {keypoints0[match.queryIdx].pt, keypoints1[match.trainIdx].pt};
+vector3d ms[2] = {calib0.unproject(pts[0]), calib1.unproject(pts[1])};
+vector4d X = phg::triangulatePoint(Ps, ms, 2);
+
+if (X(3) == 0) {
+std::cerr << "infinite point" <<
+std::endl;
+continue;
+}
+
+tie_points.push_back({
+X(0) / X(3), X(1) / X(3), X(2) / X(3)});
+
+Track track;
+track.img_kpt_pairs.push_back({
+i_camera, match.queryIdx});
+track.img_kpt_pairs.push_back({
+i_camera_prev, match.trainIdx});
+track_ids[i_camera][match.queryIdx] = tracks.
+
+size();
+
+track_ids[i_camera_prev][match.trainIdx] = tracks.
+
+size();
+
+tracks.
+push_back(track);
+} else {
+if (tracks[track_id].disabled)
+continue; // пропускаем выключенные точки (признанные выбросами)
+Track &track = tracks[track_id];
+track.img_kpt_pairs.push_back({
+i_camera, match.queryIdx});
+track_ids[i_camera][match.queryIdx] =
+track_id;
+}
+}
+}
+
+int ncameras = i_camera + 1;
+
+std::vector <vector3d> tie_points_and_cameras;
+std::vector <cv::Vec3b> tie_points_colors;
+generateTiePointsCloud(tie_points, tracks, keypoints, imgs, aligned, cameras, ncameras, tie_points_and_cameras, tie_points_colors
+);
+phg::exportPointCloud(tie_points_and_cameras, std::string("data/debug/test_sfm_ba/")
++ DATASET_DIR + "/point_cloud_" +
+to_string(ncameras)
++ "_cameras.ply", tie_points_colors);
+
+// Запуск Bundle Adjustment
+#if ENABLE_BA
+runBA(tie_points, tracks, keypoints, cameras, ncameras, calib
+);
+#endif
+
+generateTiePointsCloud(tie_points, tracks, keypoints, imgs, aligned, cameras, ncameras, tie_points_and_cameras, tie_points_colors
+);
+phg::exportPointCloud(tie_points_and_cameras, std::string("data/debug/test_sfm_ba/")
++ DATASET_DIR + "/point_cloud_" +
+to_string(ncameras)
++ "_cameras_ba.ply", tie_points_colors);
+}
+}
+
+class ReprojectionError
+{
 public:
     ReprojectionError(double x, double y) : observed_x(x), observed_y(y)
     {}
 
-    template <typename T>
-    bool operator()(const T* camera_extrinsics, // положение камеры:   [6] = {translation[3], rotation[3]} (разное для всех кадров, т.к. каждая фотография со своего ракурса)
-                    const T* camera_intrinsics, // внутренние калибровочные параметры камеры: [5] = {k1, k2, f, cx, cy} (одни и те же для всех кадров, т.к. снято на одну и ту же камеру)
-                    const T* point_global,      // 3D точка: [3]  = {x, y, z}
-                    T* residuals) const {       // невязка:  [2]  = {dx, dy}
+    template<typename T>
+    bool operator()(
+            const T *camera_extrinsics, // положение камеры:   [6] = {translation[3], rotation[3]} (разное для всех кадров, т.к. каждая фотография со своего ракурса)
+            const T *camera_intrinsics, // внутренние калибровочные параметры камеры: [5] = {k1, k2, f, cx, cy} (одни и те же для всех кадров, т.к. снято на одну и ту же камеру)
+            const T *point_global,      // 3D точка: [3]  = {x, y, z}
+            T *residuals) const
+    {       // невязка:  [2]  = {dx, dy}
         // TODO реализуйте функцию проекции, все нужно делать в типе T чтобы ceres-solver мог под него подставить как Jet (очень рекомендую посмотреть Jet.h - как класная статья из википедии!), так и double
 
-        // translation[3] - сдвиг в локальную систему координат камеры
-
-        // rotation[3] - angle-axis rotation, поворачиваем точку point->p (чтобы перейти в локальную систему координат камеры)
-        // подробнее см. https://en.wikipedia.org/wiki/Axis%E2%80%93angle_representation
-        // (P.S. у камеры всмысле вращения три степени свободы)
-
-        // Проецируем точку на фокальную плоскость матрицы (т.е. плоскость Z=фокальная длина)
+        T translation[3] = {camera_extrinsics[0], camera_extrinsics[1],
+                            camera_extrinsics[2]}; // - сдвиг в локальную систему координат камеры
+        T point[3];
+        for (size_t i = 0; i < 3; ++i)
+        {
+            point[i] = point_global[i] - translation[i];
+        }
+        T rotation[3] = {camera_extrinsics[3], camera_extrinsics[4], camera_extrinsics[5]};
+        T rotated_point[3];
+        ceres::AngleAxisRotatePoint(rotation, point, rotated_point);
+        for (int i = 0; i < 2; i++)
+        {
+            rotated_point[i] /= rotated_point[2];
+        }
 
 #if ENABLE_INSTRINSICS_K1_K2
         // k1, k2 - коэффициенты радиального искажения (radial distortion)
+        T k1 = camera_intrinsics[0], k2 = camera_intrinsics[1];
+        T r_2 = rotated_point[0] * rotated_point[0] + rotated_point[1] * rotated_point[1];
+        for (int i = 0; i < 2; i++)
+        {
+            rotated_point[i] += k1 * r_2 + k2 * r_2 * r_2;
+        }
 #endif
 
         // Домножаем на f, тем самым переводя в пиксели
+
+        T f_ = camera_intrinsics[2];
+        rotated_point[0] *= f_;
+        rotated_point[1] *= f_;
 
         // Из координат когда точка (0, 0) - центр оптической оси
         // Переходим в координаты когда точка (0, 0) - левый верхний угол картинки
         // cx, cy - координаты центра оптической оси (обычно это центр картинки, но часто он чуть смещен)
 
+        T cx_ = camera_intrinsics[3], cy_ = camera_intrinsics[4];
+        rotated_point[0] += cx_;
+        rotated_point[1] += cy_;
+
         // Теперь по спроецированным координатам не забудьте посчитать невязку репроекции
+
+        residuals[0] = rotated_point[0] - observed_x;
+        residuals[1] = rotated_point[1] - observed_y;
 
         return true;
         // TODO сверьте эту функцию с вашей реализацией проекции в src/phg/core/calibration.cpp (они должны совпадать)
     }
+
 protected:
     double observed_x;
     double observed_y;
 };
 
-void printCamera(double* camera_intrinsics)
+void printCamera(double *camera_intrinsics)
 {
     std::cout << "camera: k1=" << camera_intrinsics[0] << ", k2=" << camera_intrinsics[1] << ", "
               << "f=" << camera_intrinsics[2] << ", "
               << "cx=" << camera_intrinsics[3] << ", cy=" << camera_intrinsics[4] << std::endl;
 }
 
-void runBA(std::vector<vector3d> &tie_points,
-           std::vector<Track> &tracks,
-           std::vector<std::vector<cv::KeyPoint>> &keypoints,
-           std::vector<matrix34d> &cameras,
+void runBA(std::vector <vector3d> &tie_points,
+           std::vector <Track> &tracks,
+           std::vector <std::vector<cv::KeyPoint>> &keypoints,
+           std::vector <matrix34d> &cameras,
            int ncameras,
            phg::Calibration &calib,
            bool verbose)
@@ -430,13 +610,16 @@ void runBA(std::vector<vector3d> &tie_points,
     // Формулируем задачу
     ceres::Problem problem;
 
-    ASSERT_NEAR(calib.f_ , DATASET_F, 0.2 * DATASET_F);
+    ASSERT_NEAR(calib.f_, DATASET_F, 0.2 * DATASET_F);
     ASSERT_NEAR(calib.cx_, 0.0, 0.3 * calib.width());
     ASSERT_NEAR(calib.cy_, 0.0, 0.3 * calib.height());
 
     // внутренние калибровочные параметры камеры: [5] = {k1, k2, f, cx, cy}
     // TODO: преобразуйте calib в блок параметров камеры (ее внутренних характеристик) для оптимизации в BA
-    double camera_intrinsics[5];
+    double camera_intrinsics[5] =
+            {
+                    calib.k1_, calib.k2_, calib.f_, calib.cx_ + calib.width_ / 2.0, calib.cy_ + calib.height_ / 2.0
+            };
     std::cout << "Before BA ";
     printCamera(camera_intrinsics);
 
@@ -444,16 +627,17 @@ void runBA(std::vector<vector3d> &tie_points,
 
     // внешние калибровочные параметры камеры для каждого кадра: [6] = {translation[3], rotation[3]}
     std::vector<double> cameras_extrinsics(CAMERA_EXTRINSICS_NPARAMS * ncameras, 0.0);
-    for (size_t camera_id = 0; camera_id < ncameras; ++camera_id) {
+    for (size_t camera_id = 0; camera_id < ncameras; ++camera_id)
+    {
         matrix3d R;
         vector3d O;
         // Декомпозируем на матрицу поворота (локальная система камеры -> глобальная система координат мира)
         //                + координаты камеры в мире (т.е. ее точка отсчета)
         phg::decomposeUndistortedPMatrix(R, O, cameras[camera_id]);
 
-        double* camera_extrinsics = cameras_extrinsics.data() + CAMERA_EXTRINSICS_NPARAMS * camera_id;
-        double* translation = camera_extrinsics + 0;
-        double* rotation_angle_axis = camera_extrinsics + 3;
+        double *camera_extrinsics = cameras_extrinsics.data() + CAMERA_EXTRINSICS_NPARAMS * camera_id;
+        double *translation = camera_extrinsics + 0;
+        double *rotation_angle_axis = camera_extrinsics + 3;
 
         // AngleAxisToRotationMatrix оперирует R матрицей у которой в памяти подряд идут колонки а не строчки:
         // > Conversions between 3x3 rotation matrix (in >>>column major order<<<) and
@@ -462,7 +646,8 @@ void runBA(std::vector<vector3d> &tie_points,
         matrix3d Rt = R.t();
         ceres::RotationMatrixToAngleAxis(&(Rt(0, 0)), rotation_angle_axis);
 
-        for (int d = 0; d < 3; ++d) {
+        for (int d = 0; d < 3; ++d)
+        {
             translation[d] = O[d];
         }
     }
@@ -476,40 +661,43 @@ void runBA(std::vector<vector3d> &tie_points,
     size_t inliers = 0;
     size_t nprojections = 0;
     std::vector<double> cameras_inliers_mse(ncameras, 0.0);
-    std::vector<size_t> cameras_inliers(ncameras, 0);
-    std::vector<size_t> cameras_nprojections(ncameras, 0);
+    std::vector <size_t> cameras_inliers(ncameras, 0);
+    std::vector <size_t> cameras_nprojections(ncameras, 0);
 
-    std::vector<ceres::CostFunction*> reprojection_residuals;
-    std::vector<ceres::CostFunction*> reprojection_residuals_for_deletion;
+    std::vector < ceres::CostFunction * > reprojection_residuals;
+    std::vector < ceres::CostFunction * > reprojection_residuals_for_deletion;
 
     // Создаем невязки для всех проекций 3D точек в камеры (т.е. для всех наблюдений этих ключевых точек)
-    for (size_t i = 0; i < tie_points.size(); ++i) {
+    for (size_t i = 0; i < tie_points.size(); ++i)
+    {
         const Track &track = tracks[i];
-        for (size_t ci = 0; ci < track.img_kpt_pairs.size(); ++ci) {
+        for (size_t ci = 0; ci < track.img_kpt_pairs.size(); ++ci)
+        {
             int camera_id = track.img_kpt_pairs[ci].first;
             int keypoint_id = track.img_kpt_pairs[ci].second;
             cv::Vec2f px = keypoints[camera_id][keypoint_id].pt;
 
-            ceres::CostFunction* keypoint_reprojection_residual = new ceres::AutoDiffCostFunction<ReprojectionError,
+            ceres::CostFunction *keypoint_reprojection_residual = new ceres::AutoDiffCostFunction<ReprojectionError,
                     2, // количество невязок (размер искомого residual массива переданного в функтор, т.е. размерность искомой невязки, у нас это dx, dy (ошибка проекции по обеим осям)
                     6, 5, 3> // число параметров в каждом блоке параметров, у нас три блок параметров (внешние параметры камеры[6], внутренние параметры камеры[5] и 3D точка)
                     (new ReprojectionError(px[0], px[1]));
             reprojection_residuals.push_back(keypoint_reprojection_residual);
 
-            double* camera_extrinsics = cameras_extrinsics.data() + CAMERA_EXTRINSICS_NPARAMS * camera_id;
+            double *camera_extrinsics = cameras_extrinsics.data() + CAMERA_EXTRINSICS_NPARAMS * camera_id;
 
             // блоки параметров для 3D точек аллоцировать не обязательно, т.к. мы можем их оптимизировать напрямую в tie_points массиве
-            double* point3d_params = &(tie_points[i][0]);
+            double *point3d_params = &(tie_points[i][0]);
 
             {
-                const double* params[3];
+                const double *params[3];
                 double residual[2] = {-1.0};
                 params[0] = camera_extrinsics;
                 params[1] = camera_intrinsics;
                 params[2] = point3d_params;
                 keypoint_reprojection_residual->Evaluate(params, residual, NULL);
                 double error2 = residual[0] * residual[0] + residual[1] * residual[1];
-                if (error2 < 3.0 * sigma) {
+                if (error2 < 3.0 * sigma)
+                {
                     inliers_mse += error2;
                     ++inliers;
                     cameras_inliers_mse[camera_id] += error2;
@@ -519,31 +707,41 @@ void runBA(std::vector<vector3d> &tie_points,
                 ++cameras_nprojections[camera_id];
             }
 
-            if (!track.disabled) {
+            if (!track.disabled)
+            {
                 problem.AddResidualBlock(keypoint_reprojection_residual, new ceres::HuberLoss(3.0 * sigma),
                                          camera_extrinsics,
                                          camera_intrinsics,
                                          point3d_params);
-            } else {
+            }
+            else
+            {
                 reprojection_residuals_for_deletion.push_back(keypoint_reprojection_residual); // если мы не передали невязку в ceres-solver, то за его lifetime ответственны все еще мы
             }
         }
     }
-    std::cout << "Before BA projections: " << to_percent(inliers, nprojections) << "% inliers with MSE=" << (inliers_mse / inliers) << std::endl;
-    for (size_t camera_id = 0; camera_id < ncameras; ++camera_id) {
+    std::cout << "Before BA projections: " << to_percent(inliers, nprojections) << "% inliers with MSE="
+              << (inliers_mse / inliers) << std::endl;
+    for (size_t camera_id = 0; camera_id < ncameras; ++camera_id)
+    {
         size_t ninls = cameras_inliers[camera_id];
         size_t nproj = cameras_nprojections[camera_id];
         std::cout << "    Camera #" << camera_id << " projections: " << to_percent(ninls, nproj) << "% inliers "
-        << "(" << ninls << "/" << nproj << ") with MSE=" << (cameras_inliers_mse[camera_id] / ninls) << std::endl;
+                  << "(" << ninls << "/" << nproj << ") with MSE=" << (cameras_inliers_mse[camera_id] / ninls)
+                  << std::endl;
     }
 
-    if (ncameras < INTRINSICS_CALIBRATION_MIN_IMGS) {
+    if (ncameras < INTRINSICS_CALIBRATION_MIN_IMGS)
+    {
         // Полностью фиксируем внутренние калибровочные параметры камеры,
         // т.к. пока что наблюдений мало, и мы можем сойтись к какому-то неправильному решению которое потом не выйдет спасти
         // иначе говоря пока наблюдений мало - лучше уменьшить число степеней свободы, чтобы не испортить решение фатально
         problem.SetParameterBlockConstant(camera_intrinsics);
-    } else {
-        if (ncameras < INTRINSIC_K1_K2_MIN_IMGS) {
+    }
+    else
+    {
+        if (ncameras < INTRINSIC_K1_K2_MIN_IMGS)
+        {
             problem.SetParameterization(camera_intrinsics, new ceres::SubsetParameterization(5, {0, 1}));
         }
     }
@@ -551,24 +749,26 @@ void runBA(std::vector<vector3d> &tie_points,
     {
         // Полностью фиксируем положение первой камеры (чтобы не уползло облако точек)
         size_t camera_id = 0;
-        double* camera0_extrinsics = cameras_extrinsics.data() + CAMERA_EXTRINSICS_NPARAMS * camera_id;
+        double *camera0_extrinsics = cameras_extrinsics.data() + CAMERA_EXTRINSICS_NPARAMS * camera_id;
         problem.SetParameterBlockConstant(camera0_extrinsics);
     }
     {
         // Фиксируем координаты второй камеры, т.е. translation[3] (чтобы фиксировать масштаб)
         size_t camera_id = 1;
-        double* camera1_extrinsics = cameras_extrinsics.data() + CAMERA_EXTRINSICS_NPARAMS * camera_id;
+        double *camera1_extrinsics = cameras_extrinsics.data() + CAMERA_EXTRINSICS_NPARAMS * camera_id;
         problem.SetParameterization(camera1_extrinsics, new ceres::SubsetParameterization(6, {0, 1, 2}));
     }
 //http://ceres-solver.org/nnls_solving.html
-    if (ENABLE_BA) {
+    if (ENABLE_BA)
+    {
         ceres::Solver::Options options;
         options.linear_solver_type = ceres::DENSE_SCHUR;
         options.minimizer_progress_to_stdout = verbose;
         ceres::Solver::Summary summary;
         Solve(options, &problem, &summary);
 
-        if (verbose) {
+        if (verbose)
+        {
             std::cout << summary.BriefReport() << std::endl;
         }
     }
@@ -576,22 +776,27 @@ void runBA(std::vector<vector3d> &tie_points,
     std::cout << "After BA ";
     printCamera(camera_intrinsics);
     // TODO преобразуйте параметры камеры в обратную сторону, чтобы последующая резекция учла актуальное представление о пространстве:
-    // calib.* = camera_intrinsics[*];
+    calib.k1_ = camera_intrinsics[0];
+    calib.k2_ = camera_intrinsics[1];
+    calib.f_ = camera_intrinsics[2];
+    calib.cx_ = camera_intrinsics[3] - calib.width_ / 2.0;
+    calib.cy_ = camera_intrinsics[4] - calib.height_ / 2.0;
 
-    ASSERT_NEAR(calib.f_ , DATASET_F, 0.2 * DATASET_F);
+    ASSERT_NEAR(calib.f_, DATASET_F, 0.2 * DATASET_F);
     ASSERT_NEAR(calib.cx_, 0.0, 0.3 * calib.width());
     ASSERT_NEAR(calib.cy_, 0.0, 0.3 * calib.height());
 
-    for (size_t camera_id = 0; camera_id < ncameras; ++camera_id) {
+    for (size_t camera_id = 0; camera_id < ncameras; ++camera_id)
+    {
         matrix3d R;
         vector3d O;
 
         phg::decomposeUndistortedPMatrix(R, O, cameras[camera_id]);
         std::cout << "Camera #" << camera_id << " center: " << O << " -> ";
 
-        double* camera_extrinsics = cameras_extrinsics.data() + CAMERA_EXTRINSICS_NPARAMS * camera_id;
-        double* translation = camera_extrinsics + 0;
-        double* rotation_angle_axis = camera_extrinsics + 3;
+        double *camera_extrinsics = cameras_extrinsics.data() + CAMERA_EXTRINSICS_NPARAMS * camera_id;
+        double *translation = camera_extrinsics + 0;
+        double *rotation_angle_axis = camera_extrinsics + 3;
 
         matrix3d Rt;
         ceres::AngleAxisToRotationMatrix(rotation_angle_axis, &(Rt(0, 0)));
@@ -601,7 +806,8 @@ void runBA(std::vector<vector3d> &tie_points,
         // поэтому нужно транспонировать:
         R = Rt.t();
 
-        for (int d = 0; d < 3; ++d) {
+        for (int d = 0; d < 3; ++d)
+        {
             O[d] = translation[d];
         }
 
@@ -620,53 +826,80 @@ void runBA(std::vector<vector3d> &tie_points,
     size_t n_new_outliers = 0;
 
     size_t next_loss_k = 0;
-    for (size_t i = 0; i < tie_points.size(); ++i) {
+    for (size_t i = 0; i < tie_points.size(); ++i)
+    {
         Track &track = tracks[i];
         bool should_be_disabled = false;
 
         vector3d track_point = tie_points[i];
 
-        for (size_t ci = 0; ci < track.img_kpt_pairs.size(); ++ci) {
+        for (size_t ci = 0; ci < track.img_kpt_pairs.size(); ++ci)
+        {
             int camera_id = track.img_kpt_pairs[ci].first;
 
-            ceres::CostFunction* keypoint_reprojection_residual = reprojection_residuals[next_loss_k++];
+            ceres::CostFunction *keypoint_reprojection_residual = reprojection_residuals[next_loss_k++];
 
-            double* camera_extrinsics = cameras_extrinsics.data() + CAMERA_EXTRINSICS_NPARAMS * camera_id;
+            double *camera_extrinsics = cameras_extrinsics.data() + CAMERA_EXTRINSICS_NPARAMS * camera_id;
 
-            double* point3d_params = &(tie_points[i][0]);
+            double *point3d_params = &(tie_points[i][0]);
 
-            matrix3d R; vector3d camera_origin;
+            matrix3d R;
+            vector3d camera_origin;
             phg::decomposeUndistortedPMatrix(R, camera_origin, cameras[camera_id]);
 
-            if (ENABLE_OUTLIERS_FILTRATION_NEGATIVE_Z && ENABLE_BA) {
+            if (ENABLE_OUTLIERS_FILTRATION_NEGATIVE_Z && ENABLE_BA)
+            {
                 vector3d track_in_camera = R * (track_point - camera_origin);
                 double z = track_in_camera[2];
-                if (z < 0.0) {
+                if (z < 0.0)
+                {
                     // за спиной камеры
                     if (ENABLE_OUTLIERS_FILTRATION_NEGATIVE_Z && ENABLE_BA)
                         should_be_disabled = true;
                 }
             }
 
-            if (ENABLE_OUTLIERS_FILTRATION_COLINEAR && ENABLE_BA) {
+            if (ENABLE_OUTLIERS_FILTRATION_COLINEAR && ENABLE_BA)
+            {
                 // TODO выполните проверку случая когда два луча почти параллельны, чтобы не было странных точек улетающих на бесконечность (например чтобы угол был хотя бы 2.5 градуса)
-                // should_be_disabled = true;
+                for (size_t cj = 0; cj < track.img_kpt_pairs.size() && should_be_disabled; ++cj)
+                {
+                    if (ci == cj)
+                    {
+                        continue;
+                    }
+                    matrix3d R2;
+                    vector3d camera_origin2;
+
+                    phg::decomposeUndistortedPMatrix(R2, camera_origin2, cameras[track.img_kpt_pairs[cj].first]);
+
+                    vector3d vec1 = camera_origin - track_point;
+                    vector3d vec2 = camera_origin2 - track_point;
+
+                    if (cv::norm(vec1.cross(vec2)) > 0.95 * cv::norm(vec1) * cv::norm(vec2))
+                    {
+                        should_be_disabled = true;
+                    }
+                }
             }
 
             {
-                const double* params[3];
+                const double *params[3];
                 double residual[2] = {-1.0};
                 params[0] = camera_extrinsics;
                 params[1] = camera_intrinsics;
                 params[2] = point3d_params;
                 keypoint_reprojection_residual->Evaluate(params, residual, NULL);
                 double error2 = residual[0] * residual[0] + residual[1] * residual[1];
-                if (error2 < 3.0 * sigma) {
+                if (error2 < 3.0 * sigma)
+                {
                     inliers_mse += error2;
                     ++inliers;
                     cameras_inliers_mse[camera_id] += error2;
                     ++cameras_inliers[camera_id];
-                } else {
+                }
+                else
+                {
                     if (ENABLE_OUTLIERS_FILTRATION_3_SIGMA && ENABLE_BA)
                         should_be_disabled = true;
                 }
@@ -675,16 +908,23 @@ void runBA(std::vector<vector3d> &tie_points,
             }
         }
 
-        if (should_be_disabled && !track.disabled) {
+        if (should_be_disabled && !track.disabled)
+        {
             track.disabled = true;
             ++n_new_outliers;
-        } else if (track.disabled) {
+        }
+        else if (track.disabled)
+        {
             ++n_old_outliers;
         }
     }
-    std::cout << "After BA tie poits: " << to_percent(n_old_outliers, tie_points.size()) << "% old + " << to_percent(n_new_outliers, tie_points.size()) << "% new = " << to_percent(n_old_outliers + n_new_outliers, tie_points.size()) << "% total outliers" << std::endl;
-    std::cout << "After BA projections: " << to_percent(inliers, nprojections) << "% inliers with MSE=" << (inliers_mse / inliers) << std::endl;
-    for (size_t camera_id = 0; camera_id < ncameras; ++camera_id) {
+    std::cout << "After BA tie poits: " << to_percent(n_old_outliers, tie_points.size()) << "% old + "
+              << to_percent(n_new_outliers, tie_points.size()) << "% new = "
+              << to_percent(n_old_outliers + n_new_outliers, tie_points.size()) << "% total outliers" << std::endl;
+    std::cout << "After BA projections: " << to_percent(inliers, nprojections) << "% inliers with MSE="
+              << (inliers_mse / inliers) << std::endl;
+    for (size_t camera_id = 0; camera_id < ncameras; ++camera_id)
+    {
         size_t ninls = cameras_inliers[camera_id];
         size_t nproj = cameras_nprojections[camera_id];
         double mse = (cameras_inliers_mse[camera_id] / ninls);
@@ -693,27 +933,29 @@ void runBA(std::vector<vector3d> &tie_points,
         ASSERT_GT(ninls, 0.15 * nproj);
     }
 
-    for (auto ptr : reprojection_residuals_for_deletion) {
+    for (auto ptr: reprojection_residuals_for_deletion)
+    {
         delete ptr; // т.к. мы не отдали указатель в ceres-solver - мы ответственны за его lifetime - надо самим деаллоцировать
     }
 }
 
-void generateTiePointsCloud(const std::vector<vector3d> &tie_points,
-                            const std::vector<Track> &tracks,
-                            const std::vector<std::vector<cv::KeyPoint>> &keypoints,
-                            const std::vector<cv::Mat> &imgs,
+void generateTiePointsCloud(const std::vector <vector3d> &tie_points,
+                            const std::vector <Track> &tracks,
+                            const std::vector <std::vector<cv::KeyPoint>> &keypoints,
+                            const std::vector <cv::Mat> &imgs,
                             const std::vector<char> &aligned,
-                            const std::vector<matrix34d> &cameras,
+                            const std::vector <matrix34d> &cameras,
                             int ncameras,
-                            std::vector<vector3d> &tie_points_and_cameras,
-                            std::vector<cv::Vec3b> &tie_points_colors)
+                            std::vector <vector3d> &tie_points_and_cameras,
+                            std::vector <cv::Vec3b> &tie_points_colors)
 {
     rassert(tie_points.size() == tracks.size(), 24152151251241);
 
     tie_points_and_cameras.clear();
     tie_points_colors.clear();
 
-    for (int i = 0; i < (int) tie_points.size(); ++i) {
+    for (int i = 0; i < (int) tie_points.size(); ++i)
+    {
         const Track &track = tracks[i];
         if (track.disabled)
             continue;
@@ -725,8 +967,10 @@ void generateTiePointsCloud(const std::vector<vector3d> &tie_points,
         tie_points_colors.push_back(imgs[img].at<cv::Vec3b>(px[1], px[0]));
     }
 
-    for (int i_camera = 0; i_camera < ncameras; ++i_camera) {
-        if (!aligned[i_camera]) {
+    for (int i_camera = 0; i_camera < ncameras; ++i_camera)
+    {
+        if (!aligned[i_camera])
+        {
             throw std::runtime_error("camera " + std::to_string(i_camera) + " is not aligned");
         }
 


### PR DESCRIPTION
# Перечислите идеи и коротко обозначьте мысли которые у вас возникали по мере выполнения задания, в частности попробуйте ответить на вопросы:

1) test_ceres_solver/FitLine: почему найденная прямая и эталонная - не совпадают? Как это исправить пост-обработкой? Как это исправить формулировкой задачи?

На постобработке можно привести решение и эталон к одному масштабу

2) BA: представьте что вы написали преобразование phg::Calibration -> блок параметров и обратное блок параметров -> phg::Calibration. Как проверить простым образом что эти преобразования сделаны корректно? Что должно быть в логе про процент inliers до/после BA если runBA() вызывать всегда два раза пордяд? Иначе говоря - что следует из того что в идеале runBA() должна быть (мне очень нравится это слово) - [идемпотентна](https://ru.wikipedia.org/wiki/%D0%98%D0%B4%D0%B5%D0%BC%D0%BF%D0%BE%D1%82%D0%B5%D0%BD%D1%82%D0%BD%D0%BE%D1%81%D1%82%D1%8C)?

По идее близко к 100. Т.к. второй вызов BA не должен менять параметры, а если  меняет, значит первый вызов недостаточно их оптимизировал, значит набагали где-то

3) Какое максимальное число кадров у вас получилось хорошо выравнять для каждого из датасетов? (проверьте хотя бы saharov32 и herzjesu25) Не забудьте приложить скриншоты.

Скриншоты приложить пока не могу, но тесты прошли все (ставлю MeshLab, это дольше, чем я думал)

4) Если бы вычисления в double были абсолютно точны - можно ли было бы назвать вычисления в Calibration::project/unproject строго зеркальными?

Дело не в double, а в r, он неизвестен

5) Почему фокальная длина меняется от того что мы уменьшаем картинку? Почему именно f/downscale?

В противном случае у нас меняется FOV

6) Имеет ли право BA двигать точку отсчета системы координат (т.е. добавить константу ко всем координатам)? Как это повлияет на суммарную Loss?

Да может, на проекцию это влиять не должно, следовательно Loss не поменяется

7) Каким образом можно гарантировать чтобы при сравнении нескольких последовательно построенных облаков точек одного и того же датасета (созданных по мере добавления фотографии за фотографией) в MeshLab - облака не были хаотично смещены/отмасштабированы/повернуты друг от друга?

А разве BA это не гарантирует? Камеры откалиброваны, все считают в одной системе отсчета, если облака смещены, то и лосс большой, т.к. на каком-то фото (по сути камере) неправильные калибровочные параметры

100) Если есть - фидбек/идеи по улучшению задания.


// Создайте PR.
// Дождитесь отработки Travis CI, после чего нажмите на зеленую галочку -> Details -> The build -> скопируйте весь лог тестирования.
// Откройте PR на редактирование (сверху справа три точки->Edit) и добавьте сюда скопированный лог тестирования внутри тега <pre> для сохранения форматирования и под спойлером для компактности и удобства:

<details><summary>Travis CI</summary><p>

<pre>
$ ./build/test_ceres_solver
Running main() from /home/runner/work/PhotogrammetryTasks2024/PhotogrammetryTasks2024/libs/3rdparty/libgtest/googletest/src/gtest_main.cc
[==========] Running 5 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 5 tests from CeresSolver
[ RUN      ] CeresSolver.HelloWorld1
iter      cost      cost_change  |gradient|   |step|    tr_ratio  tr_radius  ls_iter  iter_time  total_time
   0  1.250000e+01    0.00e+00    5.00e+00   0.00e+00   0.00e+00  1.00e+04        0    1.41e-05    8.01e-05
   1  1.249750e-07    1.25e+01    5.00e-04   5.00e+00   1.00e+00  3.00e+04        1    2.50e-05    1.40e-04
   2  1.388518e-16    1.25e-07    1.67e-08   5.00e-04   1.00e+00  9.00e+04        1    4.05e-06    1.60e-04
Ceres Solver Report: Iterations: 3, Initial cost: 1.250000e+01, Final cost: 1.388518e-16, Termination: CONVERGENCE
x:     5 -> 10
f(x):  5 -> 1.66644e-08
f'(x): -1 -> -1
[       OK ] CeresSolver.HelloWorld1 (0 ms)
[ RUN      ] CeresSolver.HelloWorld2
iter      cost      cost_change  |gradient|   |step|    tr_ratio  tr_radius  ls_iter  iter_time  total_time
   0  6.131250e+04    0.00e+00    1.40e+04   0.00e+00   0.00e+00  1.00e+04        0    4.05e-06    2.41e-05
   1  3.127313e+04    3.00e+04    7.82e+03   4.47e+01   4.90e-01  1.00e+04        1    9.06e-06    5.01e-05
   2  5.685772e+02    3.07e+04    7.75e+02   1.01e+02   9.82e-01  3.00e+04        1    5.01e-06    7.10e-05
   3  1.137952e+02    4.55e+02    2.90e+02   2.55e+01   8.00e-01  3.83e+04        1    5.01e-06    8.89e-05
   4  1.931689e+00    1.12e+02    3.82e+01   1.97e+01   9.83e-01  1.15e+05        1    4.05e-06    1.06e-04
   5  6.620880e-01    1.27e+00    2.23e+01   4.56e+00   6.57e-01  1.18e+05        1    4.05e-06    1.23e-04
   6  1.715778e-02    6.45e-01    2.45e+00   4.10e+00   9.74e-01  3.55e+05        1    4.05e-06    1.39e-04
   7  2.040825e-03    1.51e-02    8.69e-01   8.05e-01   8.81e-01  6.37e+05        1    3.81e-06    1.55e-04
   8  3.955432e-04    1.65e-03    1.23e-01   8.19e-01   8.06e-01  8.28e+05        1    5.01e-06    1.72e-04
   9  4.204592e-05    3.53e-04    3.09e-02   1.49e-01   8.94e-01  1.62e+06        1    4.05e-06    1.93e-04
  10  1.366023e-05    2.84e-05    5.85e-03   1.57e-01   6.75e-01  1.69e+06        1    5.01e-06    2.10e-04
  11  1.455687e-06    1.22e-05    7.13e-04   2.79e-02   8.93e-01  3.29e+06        1    4.05e-06    2.26e-04
  12  4.821191e-07    9.74e-07    7.85e-04   2.95e-02   6.69e-01  3.43e+06        1    5.01e-06    2.45e-04
  13  5.128650e-08    4.31e-07    2.64e-04   5.24e-03   8.94e-01  6.69e+06        1    4.05e-06    2.61e-04
  14  1.696961e-08    3.43e-08    1.71e-04   5.54e-03   6.69e-01  6.96e+06        1    4.05e-06    2.77e-04
  15  1.803689e-09    1.52e-08    5.60e-05   9.82e-04   8.94e-01  1.36e+07        1    4.05e-06    2.93e-04
  16  5.966373e-10    1.21e-09    3.29e-05   1.04e-03   6.69e-01  1.41e+07        1    4.05e-06    3.09e-04
  17  6.339313e-11    5.33e-10    1.07e-05   1.84e-04   8.94e-01  2.77e+07        1    4.05e-06    3.29e-04
  18  2.096924e-11    4.24e-11    6.19e-06   1.95e-04   6.69e-01  2.88e+07        1    4.05e-06    3.45e-04
  19  2.227619e-12    1.87e-11    2.02e-06   3.45e-05   8.94e-01  5.62e+07        1    4.77e-06    3.62e-04
  20  7.368654e-13    1.49e-12    1.16e-06   3.65e-05   6.69e-01  5.85e+07        1    4.05e-06    3.78e-04
  21  7.827280e-14    6.59e-13    3.79e-07   6.47e-06   8.94e-01  1.14e+08        1    4.05e-06    3.94e-04
  22  2.589188e-14    5.24e-14    2.18e-07   6.84e-06   6.69e-01  1.19e+08        1    5.01e-06    4.11e-04
Ceres Solver Report: Iterations: 23, Initial cost: 6.131250e+04, Final cost: 2.589188e-14, Termination: CONVERGENCE
Found intersection point: (10, 5, 200)
[       OK ] CeresSolver.HelloWorld2 (1 ms)
[ RUN      ] CeresSolver.FitLineNoise
iter      cost      cost_change  |gradient|   |step|    tr_ratio  tr_radius  ls_iter  iter_time  total_time
   0  4.506761e+07    0.00e+00    1.61e+08   0.00e+00   0.00e+00  1.00e+04        0    1.13e-04    1.81e-04
   1  4.658321e+02    4.51e+07    1.33e+04   1.00e+02   1.00e+00  3.00e+04        1    2.39e-04    4.33e-04
   2  4.654480e+02    3.84e-01    1.61e-01   5.13e-03   1.00e+00  9.00e+04        1    3.50e-04    7.94e-04
Ceres Solver Report: Iterations: 3, Initial cost: 4.506761e+07, Final cost: 4.654480e+02, Termination: CONVERGENCE
Found line: (a=-0.500026, b=0.999948, c=-100.052)
[       OK ] CeresSolver.FitLineNoise (2 ms)
[ RUN      ] CeresSolver.FitLineNoiseAndOutliers
iter      cost      cost_change  |gradient|   |step|    tr_ratio  tr_radius  ls_iter  iter_time  total_time
   0  1.201187e+08    0.00e+00    1.37e+08   0.00e+00   0.00e+00  1.00e+04        0    1.06e-04    1.55e-04
   1  7.448902e+07    4.56e+07    5.33e+07   8.51e+01   1.41e+00  3.00e+04        1    2.06e-04    3.73e-04
   2  6.772855e+07    6.76e+06    1.27e+07   1.55e+01   1.41e+00  9.00e+04        1    2.03e-04    5.85e-04
   3  6.739936e+07    3.29e+05    3.88e+06   2.30e+00   1.33e+00  2.70e+05        1    2.38e-04    8.32e-04
   4  6.736832e+07    3.10e+04    1.21e+06   6.64e-01   1.32e+00  8.10e+05        1    2.05e-04    1.05e-03
   5  6.736525e+07    3.07e+03    3.83e+05   2.05e-01   1.32e+00  2.43e+06        1    1.97e-04    1.25e-03
   6  6.736495e+07    3.06e+02    1.21e+05   6.45e-02   1.32e+00  7.29e+06        1    2.22e-04    1.48e-03
Ceres Solver Report: Iterations: 7, Initial cost: 1.201187e+08, Final cost: 6.736495e+07, Termination: CONVERGENCE
Found line: (a=-0.549481, b=0.767491, c=-66.3904)
[       OK ] CeresSolver.FitLineNoiseAndOutliers (2 ms)
[ RUN      ] CeresSolver.FitLineNoiseAndOutliersWithHuberLoss
iter      cost      cost_change  |gradient|   |step|    tr_ratio  tr_radius  ls_iter  iter_time  total_time
   0  1.096949e+06    0.00e+00    1.13e+06   0.00e+00   0.00e+00  1.00e+04        0    1.45e-04    2.11e-04
   1  5.506564e+05    5.46e+05    1.19e+06   8.24e+01   2.14e+00  3.00e+04        1    2.84e-04    5.08e-04
   2  4.578101e+05    9.28e+04    9.63e+05   6.74e+00   1.74e+00  9.00e+04        1    2.64e-04    7.93e-04
   3  4.504957e+05    7.31e+03    2.85e+05   3.04e-01   1.65e+00  2.70e+05        1    2.69e-04    1.08e-03
   4  4.503340e+05    1.62e+02    4.22e+03   1.43e-02   1.02e+00  8.10e+05        1    2.33e-04    1.32e-03
Ceres Solver Report: Iterations: 5, Initial cost: 1.096949e+06, Final cost: 4.503340e+05, Termination: CONVERGENCE
Found line: (a=-0.445255, b=0.889226, c=-88.902)
[       OK ] CeresSolver.FitLineNoiseAndOutliersWithHuberLoss (2 ms)
[----------] 5 tests from CeresSolver (7 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test suite ran. (7 ms total)
[  PASSED  ] 5 tests.

$ ./build/test_sfm_ba
Running main() from /home/runner/work/PhotogrammetryTasks2024/PhotogrammetryTasks2024/libs/3rdparty/libgtest/googletest/src/gtest_main.cc
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from SFM
[ RUN      ] SFM.ReconstructNViews
32 images
detecting points...
matching points...
1% - Cameras 0-1 (IMG_3023.JPG-IMG_3024.JPG): 1159 matches
4% - Cameras 3-0 (IMG_3026.JPG-IMG_3023.JPG): 180 matches
6% - Cameras 0-2 (IMG_3023.JPG-IMG_3025.JPG): 442 matches
7% - Cameras 6-1 (IMG_3029.JPG-IMG_3024.JPG): 37 matches
9% - Cameras 3-1 (IMG_3026.JPG-IMG_3024.JPG): 408 matches
10% - Cameras 0-3 (IMG_3023.JPG-IMG_3026.JPG): 148 matches
11% - Cameras 6-2 (IMG_3029.JPG-IMG_3025.JPG): 61 matches
13% - Cameras 3-2 (IMG_3026.JPG-IMG_3025.JPG): 1229 matches
14% - Cameras 0-4 (IMG_3023.JPG-IMG_3027.JPG): 53 matches
16% - Cameras 6-3 (IMG_3029.JPG-IMG_3026.JPG): 289 matches
17% - Cameras 8-3 (IMG_3031.JPG-IMG_3026.JPG): 21 matches
18% - Cameras 3-4 (IMG_3026.JPG-IMG_3027.JPG): 1526 matches
20% - Cameras 6-4 (IMG_3029.JPG-IMG_3027.JPG): 896 matches
21% - Cameras 8-4 (IMG_3031.JPG-IMG_3027.JPG): 182 matches
22% - Cameras 3-5 (IMG_3026.JPG-IMG_3028.JPG): 765 matches
24% - Cameras 6-5 (IMG_3029.JPG-IMG_3028.JPG): 1668 matches
26% - Cameras 8-5 (IMG_3031.JPG-IMG_3028.JPG): 361 matches
27% - Cameras 3-6 (IMG_3026.JPG-IMG_3029.JPG): 268 matches
29% - Cameras 6-7 (IMG_3029.JPG-IMG_3030.JPG): 1549 matches
30% - Cameras 8-6 (IMG_3031.JPG-IMG_3029.JPG): 876 matches
31% - Cameras 3-7 (IMG_3026.JPG-IMG_3030.JPG): 80 matches
33% - Cameras 6-8 (IMG_3029.JPG-IMG_3031.JPG): 805 matches
34% - Cameras 8-7 (IMG_3031.JPG-IMG_3030.JPG): 1254 matches
38% - Cameras 6-9 (IMG_3029.JPG-IMG_3032.JPG): 469 matches
39% - Cameras 8-9 (IMG_3031.JPG-IMG_3032.JPG): 1556 matches
40% - Cameras 1-0 (IMG_3024.JPG-IMG_3023.JPG): 1021 matches
44% - Cameras 4-0 (IMG_3027.JPG-IMG_3023.JPG): 78 matches
46% - Cameras 1-2 (IMG_3024.JPG-IMG_3025.JPG): 1145 matches
49% - Cameras 4-1 (IMG_3027.JPG-IMG_3024.JPG): 148 matches
50% - Cameras 1-3 (IMG_3024.JPG-IMG_3026.JPG): 324 matches
53% - Cameras 4-2 (IMG_3027.JPG-IMG_3025.JPG): 653 matches
54% - Cameras 1-4 (IMG_3024.JPG-IMG_3027.JPG): 128 matches
56% - Cameras 7-3 (IMG_3030.JPG-IMG_3026.JPG): 100 matches
58% - Cameras 4-3 (IMG_3027.JPG-IMG_3026.JPG): 1678 matches
60% - Cameras 7-4 (IMG_3030.JPG-IMG_3027.JPG): 311 matches
61% - Cameras 9-4 (IMG_3032.JPG-IMG_3027.JPG): 77 matches
62% - Cameras 4-5 (IMG_3027.JPG-IMG_3028.JPG): 1380 matches
64% - Cameras 7-5 (IMG_3030.JPG-IMG_3028.JPG): 999 matches
66% - Cameras 9-5 (IMG_3032.JPG-IMG_3028.JPG): 289 matches
67% - Cameras 4-6 (IMG_3027.JPG-IMG_3029.JPG): 1052 matches
69% - Cameras 7-6 (IMG_3030.JPG-IMG_3029.JPG): 1571 matches
70% - Cameras 9-6 (IMG_3032.JPG-IMG_3029.JPG): 454 matches
71% - Cameras 4-7 (IMG_3027.JPG-IMG_3030.JPG): 263 matches
73% - Cameras 7-8 (IMG_3030.JPG-IMG_3031.JPG): 1199 matches
74% - Cameras 9-7 (IMG_3032.JPG-IMG_3030.JPG): 738 matches
76% - Cameras 4-8 (IMG_3027.JPG-IMG_3031.JPG): 145 matches
78% - Cameras 7-9 (IMG_3030.JPG-IMG_3032.JPG): 731 matches
79% - Cameras 9-8 (IMG_3032.JPG-IMG_3031.JPG): 1587 matches
80% - Cameras 4-9 (IMG_3027.JPG-IMG_3032.JPG): 129 matches
81% - Cameras 2-0 (IMG_3025.JPG-IMG_3023.JPG): 509 matches
83% - Cameras 2-1 (IMG_3025.JPG-IMG_3024.JPG): 1157 matches
84% - Cameras 5-1 (IMG_3028.JPG-IMG_3024.JPG): 20 matches
86% - Cameras 2-3 (IMG_3025.JPG-IMG_3026.JPG): 1256 matches
87% - Cameras 5-2 (IMG_3028.JPG-IMG_3025.JPG): 149 matches
88% - Cameras 2-4 (IMG_3025.JPG-IMG_3027.JPG): 648 matches
89% - Cameras 5-3 (IMG_3028.JPG-IMG_3026.JPG): 850 matches
90% - Cameras 2-5 (IMG_3025.JPG-IMG_3028.JPG): 116 matches
91% - Cameras 5-4 (IMG_3028.JPG-IMG_3027.JPG): 1389 matches
92% - Cameras 2-6 (IMG_3025.JPG-IMG_3029.JPG): 56 matches
93% - Cameras 5-6 (IMG_3028.JPG-IMG_3029.JPG): 1790 matches
94% - Cameras 2-7 (IMG_3025.JPG-IMG_3030.JPG): 38 matches
96% - Cameras 5-7 (IMG_3028.JPG-IMG_3030.JPG): 1025 matches
98% - Cameras 5-8 (IMG_3028.JPG-IMG_3031.JPG): 370 matches
100% - Cameras 5-9 (IMG_3028.JPG-IMG_3032.JPG): 336 matches
Initial alignment from cameras #0 and #1 (IMG_3023.JPG, IMG_3024.JPG)
Before BA camera: k1=0, k2=0, f=1585.5, cx=364, cy=546
Before BA projections: 89% inliers with MSE=1.71016
    Camera #0 projections: 89% inliers (1037/1159) with MSE=1.68797
    Camera #1 projections: 89% inliers (1035/1159) with MSE=1.73239
After BA camera: k1=0, k2=0, f=1585.5, cx=364, cy=546
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
After BA tie poits: 0% old + 11% new = 11% total outliers
After BA projections: 89% inliers with MSE=0.36941
    Camera #0 projections: 89% inliers (1027/1159) with MSE=0.374369
    Camera #1 projections: 89% inliers (1028/1159) with MSE=0.364456
Append camera #2 (IMG_3025.JPG) to alignment via 792 common points
Before BA camera: k1=0, k2=0, f=1585.5, cx=364, cy=546
Before BA projections: 64% inliers with MSE=0.697122
    Camera #0 projections: 83% inliers (1095/1324) with MSE=0.392793
    Camera #1 projections: 77% inliers (1386/1810) with MSE=0.569545
    Camera #2 projections: 35% inliers (577/1639) with MSE=1.58111
After BA camera: k1=0, k2=0, f=1585.5, cx=364, cy=546
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
Camera #2 center: [-1.75432, 0.0435193, 0.691639] -> [-1.9332, 0.0213844, 0.574549]
After BA tie poits: 7% old + 7% new = 14% total outliers
After BA projections: 89% inliers with MSE=0.650715
    Camera #0 projections: 84% inliers (1109/1324) with MSE=0.98434
    Camera #1 projections: 89% inliers (1604/1810) with MSE=0.752057
    Camera #2 projections: 93% inliers (1518/1639) with MSE=0.299898
Append camera #3 (IMG_3026.JPG) to alignment via 984 common points
Before BA camera: k1=0, k2=0, f=1585.5, cx=364, cy=546
Before BA projections: 77% inliers with MSE=0.90909
    Camera #0 projections: 84% inliers (1125/1346) with MSE=0.986453
    Camera #1 projections: 88% inliers (1638/1853) with MSE=0.755548
    Camera #2 projections: 80% inliers (1832/2293) with MSE=0.466373
    Camera #3 projections: 56% inliers (975/1738) with MSE=1.90963
After BA camera: k1=0, k2=0, f=1585.5, cx=364, cy=546
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
Camera #2 center: [-1.9332, 0.0213844, 0.574549] -> [-1.90091, 0.0101914, 0.499642]
Camera #3 center: [-2.70342, 0.0419379, 1.14095] -> [-2.73193, 0.0164815, 0.915656]
After BA tie poits: 10% old + 6% new = 16% total outliers
After BA projections: 86% inliers with MSE=0.407085
    Camera #0 projections: 81% inliers (1095/1346) with MSE=1.02692
    Camera #1 projections: 85% inliers (1570/1853) with MSE=0.532744
    Camera #2 projections: 88% inliers (2028/2293) with MSE=0.166646
    Camera #3 projections: 89% inliers (1551/1738) with MSE=0.156667
Append camera #4 (IMG_3027.JPG) to alignment via 1134 common points
Before BA camera: k1=0, k2=0, f=1585.5, cx=364, cy=546
Before BA projections: 87% inliers with MSE=0.512175
    Camera #0 projections: 81% inliers (1103/1354) with MSE=1.02263
    Camera #1 projections: 85% inliers (1581/1865) with MSE=0.530324
    Camera #2 projections: 88% inliers (2189/2475) with MSE=0.178846
    Camera #3 projections: 91% inliers (2383/2618) with MSE=0.164083
    Camera #4 projections: 85% inliers (2061/2417) with MSE=0.981577
After BA camera: k1=0, k2=0, f=1707.05, cx=319.351, cy=505.84
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
Camera #2 center: [-1.90091, 0.0101914, 0.499642] -> [-1.87127, 0.0185203, 0.528922]
Camera #3 center: [-2.73193, 0.0164815, 0.915656] -> [-2.65834, 0.0353923, 0.956179]
Camera #4 center: [-3.34626, 0.0488612, 1.5019] -> [-3.22971, 0.0757299, 1.54206]
After BA tie poits: 12% old + 5% new = 17% total outliers
After BA projections: 84% inliers with MSE=0.218122
    Camera #0 projections: 78% inliers (1053/1354) with MSE=0.396043
    Camera #1 projections: 82% inliers (1530/1865) with MSE=0.223259
    Camera #2 projections: 85% inliers (2097/2475) with MSE=0.168933
    Camera #3 projections: 88% inliers (2315/2618) with MSE=0.195517
    Camera #4 projections: 83% inliers (2013/2417) with MSE=0.198384
Append camera #5 (IMG_3028.JPG) to alignment via 1132 common points
Before BA camera: k1=0, k2=0, f=1707.05, cx=319.351, cy=505.84
Before BA projections: 84% inliers with MSE=0.407035
    Camera #0 projections: 78% inliers (1053/1354) with MSE=0.396043
    Camera #1 projections: 82% inliers (1531/1867) with MSE=0.223282
    Camera #2 projections: 85% inliers (2108/2489) with MSE=0.171912
    Camera #3 projections: 88% inliers (2505/2834) with MSE=0.271134
    Camera #4 projections: 85% inliers (2609/3055) with MSE=0.346992
    Camera #5 projections: 84% inliers (1733/2062) with MSE=1.14888
After BA camera: k1=0, k2=0, f=1649.2, cx=324.435, cy=515.111
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
Camera #2 center: [-1.87127, 0.0185203, 0.528922] -> [-1.87569, 0.017992, 0.523627]
Camera #3 center: [-2.65834, 0.0353923, 0.956179] -> [-2.66811, 0.0345145, 0.943554]
Camera #4 center: [-3.22971, 0.0757299, 1.54206] -> [-3.24627, 0.0752875, 1.52204]
Camera #5 center: [-3.75066, 0.113421, 2.25747] -> [-3.76232, 0.125518, 2.2418]
After BA tie poits: 14% old + 4% new = 17% total outliers
After BA projections: 83% inliers with MSE=0.210426
    Camera #0 projections: 77% inliers (1040/1354) with MSE=0.425028
    Camera #1 projections: 81% inliers (1511/1867) with MSE=0.226726
    Camera #2 projections: 83% inliers (2059/2489) with MSE=0.140356
    Camera #3 projections: 84% inliers (2373/2834) with MSE=0.152814
    Camera #4 projections: 84% inliers (2554/3055) with MSE=0.199767
    Camera #5 projections: 89% inliers (1826/2062) with MSE=0.243501
Append camera #6 (IMG_3029.JPG) to alignment via 1359 common points
Before BA camera: k1=0, k2=0, f=1649.2, cx=324.435, cy=515.111
Before BA projections: 84% inliers with MSE=0.490049
    Camera #0 projections: 77% inliers (1040/1354) with MSE=0.425028
    Camera #1 projections: 81% inliers (1518/1874) with MSE=0.22594
    Camera #2 projections: 83% inliers (2061/2491) with MSE=0.140267
    Camera #3 projections: 84% inliers (2388/2853) with MSE=0.152162
    Camera #4 projections: 84% inliers (2763/3299) with MSE=0.33139
    Camera #5 projections: 89% inliers (2659/2975) with MSE=0.519156
    Camera #6 projections: 86% inliers (2279/2656) with MSE=1.5244
After BA camera: k1=0.00402451, k2=-0.0787346, f=1628.02, cx=335.073, cy=533.229
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
Camera #2 center: [-1.87569, 0.017992, 0.523627] -> [-1.87918, 0.0149585, 0.514287]
Camera #3 center: [-2.66811, 0.0345145, 0.943554] -> [-2.67987, 0.0279461, 0.927919]
Camera #4 center: [-3.24627, 0.0752875, 1.52204] -> [-3.27068, 0.0638882, 1.49891]
Camera #5 center: [-3.76232, 0.125518, 2.2418] -> [-3.7965, 0.107671, 2.20187]
Camera #6 center: [-3.98059, 0.219396, 3.10378] -> [-4.02859, 0.185002, 3.04616]
After BA tie poits: 14% old + 4% new = 18% total outliers
After BA projections: 83% inliers with MSE=0.191327
    Camera #0 projections: 76% inliers (1035/1354) with MSE=0.50606
    Camera #1 projections: 80% inliers (1504/1874) with MSE=0.256398
    Camera #2 projections: 82% inliers (2033/2491) with MSE=0.125989
    Camera #3 projections: 81% inliers (2321/2853) with MSE=0.123078
    Camera #4 projections: 81% inliers (2677/3299) with MSE=0.172099
    Camera #5 projections: 86% inliers (2562/2975) with MSE=0.166883
    Camera #6 projections: 87% inliers (2317/2656) with MSE=0.183436
Append camera #7 (IMG_3030.JPG) to alignment via 1633 common points
Before BA camera: k1=0.00402451, k2=-0.0787346, f=1628.02, cx=335.073, cy=533.229
Before BA projections: 83% inliers with MSE=0.259189
    Camera #0 projections: 76% inliers (1035/1354) with MSE=0.50606
    Camera #1 projections: 80% inliers (1504/1874) with MSE=0.256398
    Camera #2 projections: 82% inliers (2033/2491) with MSE=0.125989
    Camera #3 projections: 81% inliers (2322/2854) with MSE=0.12303
    Camera #4 projections: 81% inliers (2691/3324) with MSE=0.172978
    Camera #5 projections: 86% inliers (2763/3203) with MSE=0.175206
    Camera #6 projections: 88% inliers (2926/3314) with MSE=0.178965
    Camera #7 projections: 83% inliers (2170/2621) with MSE=0.73588
After BA camera: k1=-0.00418796, k2=0.0380252, f=1577.57, cx=339.813, cy=550.143
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
Camera #2 center: [-1.87918, 0.0149585, 0.514287] -> [-1.88023, 0.0130712, 0.509973]
Camera #3 center: [-2.67987, 0.0279461, 0.927919] -> [-2.68076, 0.0234883, 0.91696]
Camera #4 center: [-3.27068, 0.0638882, 1.49891] -> [-3.27161, 0.0558007, 1.47918]
Camera #5 center: [-3.7965, 0.107671, 2.20187] -> [-3.80083, 0.0944256, 2.16878]
Camera #6 center: [-4.02859, 0.185002, 3.04616] -> [-4.04283, 0.16426, 2.99813]
Camera #7 center: [-4.16563, 0.268503, 3.96891] -> [-4.20654, 0.23935, 3.91193]
After BA tie poits: 15% old + 3% new = 19% total outliers
After BA projections: 82% inliers with MSE=0.179863
    Camera #0 projections: 76% inliers (1032/1354) with MSE=0.589234
    Camera #1 projections: 80% inliers (1490/1874) with MSE=0.283908
    Camera #2 projections: 81% inliers (2013/2491) with MSE=0.121141
    Camera #3 projections: 80% inliers (2270/2854) with MSE=0.108164
    Camera #4 projections: 78% inliers (2594/3324) with MSE=0.135776
    Camera #5 projections: 83% inliers (2645/3203) with MSE=0.156018
    Camera #6 projections: 85% inliers (2820/3314) with MSE=0.148782
    Camera #7 projections: 89% inliers (2325/2621) with MSE=0.166337
Append camera #8 (IMG_3031.JPG) to alignment via 1472 common points
Before BA camera: k1=-0.00418796, k2=0.0380252, f=1577.57, cx=339.813, cy=550.143
Before BA projections: 78% inliers with MSE=0.353272
    Camera #0 projections: 76% inliers (1032/1354) with MSE=0.589234
    Camera #1 projections: 80% inliers (1490/1874) with MSE=0.283908
    Camera #2 projections: 81% inliers (2013/2491) with MSE=0.121141
    Camera #3 projections: 80% inliers (2271/2855) with MSE=0.108244
    Camera #4 projections: 78% inliers (2603/3336) with MSE=0.136909
    Camera #5 projections: 83% inliers (2670/3236) with MSE=0.163418
    Camera #6 projections: 82% inliers (2891/3541) with MSE=0.158639
    Camera #7 projections: 86% inliers (2683/3137) with MSE=0.200402
    Camera #8 projections: 53% inliers (1234/2319) with MSE=2.72484
After BA camera: k1=-0.00167713, k2=-0.00549508, f=1585.48, cx=341.674, cy=549.417
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
Camera #2 center: [-1.88023, 0.0130712, 0.509973] -> [-1.8803, 0.0125642, 0.507987]
Camera #3 center: [-2.68076, 0.0234883, 0.91696] -> [-2.68348, 0.0223891, 0.914695]
Camera #4 center: [-3.27161, 0.0558007, 1.47918] -> [-3.27682, 0.0544291, 1.47727]
Camera #5 center: [-3.80083, 0.0944256, 2.16878] -> [-3.80827, 0.0929416, 2.16807]
Camera #6 center: [-4.04283, 0.16426, 2.99813] -> [-4.05293, 0.163148, 2.9991]
Camera #7 center: [-4.20654, 0.23935, 3.91193] -> [-4.21655, 0.237864, 3.91511]
Camera #8 center: [-3.93104, 0.360604, 4.93885] -> [-3.94356, 0.315018, 4.95531]
After BA tie poits: 17% old + 3% new = 19% total outliers
After BA projections: 81% inliers with MSE=0.19386
    Camera #0 projections: 76% inliers (1030/1354) with MSE=0.598905
    Camera #1 projections: 79% inliers (1488/1874) with MSE=0.289303
    Camera #2 projections: 80% inliers (2005/2491) with MSE=0.123736
    Camera #3 projections: 79% inliers (2243/2855) with MSE=0.105231
    Camera #4 projections: 77% inliers (2559/3336) with MSE=0.159262
    Camera #5 projections: 80% inliers (2578/3236) with MSE=0.161892
    Camera #6 projections: 83% inliers (2924/3541) with MSE=0.168566
    Camera #7 projections: 88% inliers (2747/3137) with MSE=0.205777
    Camera #8 projections: 88% inliers (2037/2319) with MSE=0.190108
Append camera #9 (IMG_3032.JPG) to alignment via 1524 common points
Before BA camera: k1=-0.00167713, k2=-0.00549508, f=1585.48, cx=341.674, cy=549.417
Before BA projections: 80% inliers with MSE=0.229827
    Camera #0 projections: 76% inliers (1030/1354) with MSE=0.598905
    Camera #1 projections: 79% inliers (1488/1874) with MSE=0.289303
    Camera #2 projections: 80% inliers (2005/2491) with MSE=0.123736
    Camera #3 projections: 79% inliers (2243/2855) with MSE=0.105231
    Camera #4 projections: 77% inliers (2560/3337) with MSE=0.159295
    Camera #5 projections: 80% inliers (2596/3258) with MSE=0.163098
    Camera #6 projections: 83% inliers (2944/3564) with MSE=0.168252
    Camera #7 projections: 86% inliers (2816/3292) with MSE=0.203853
    Camera #8 projections: 79% inliers (2512/3183) with MSE=0.237031
    Camera #9 projections: 77% inliers (2022/2639) with MSE=0.53331
After BA camera: k1=-0.00350494, k2=-0.0573244, f=1647.77, cx=345.223, cy=546.791
Camera #0 center: [0, 0, 0] -> [0, 0, 0]
Camera #1 center: [-0.981112, 0.0066058, 0.193329] -> [-0.981112, 0.0066058, 0.193329]
Camera #2 center: [-1.8803, 0.0125642, 0.507987] -> [-1.88136, 0.0114712, 0.508757]
Camera #3 center: [-2.68348, 0.0223891, 0.914695] -> [-2.68309, 0.0192121, 0.918847]
Camera #4 center: [-3.27682, 0.0544291, 1.47727] -> [-3.2742, 0.0490223, 1.48342]
Camera #5 center: [-3.80827, 0.0929416, 2.16807] -> [-3.79942, 0.0843194, 2.17587]
Camera #6 center: [-4.05293, 0.163148, 2.9991] -> [-4.03843, 0.151421, 3.00302]
Camera #7 center: [-4.21655, 0.237864, 3.91511] -> [-4.19627, 0.221453, 3.91104]
Camera #8 center: [-3.94356, 0.315018, 4.95531] -> [-3.92877, 0.29142, 4.91733]
Camera #9 center: [-3.57331, 0.382423, 5.89554] -> [-3.55736, 0.339549, 5.87394]
After BA tie poits: 17% old + 2% new = 18% total outliers
After BA projections: 81% inliers with MSE=0.159977
    Camera #0 projections: 76% inliers (1029/1354) with MSE=0.594235
    Camera #1 projections: 79% inliers (1481/1874) with MSE=0.282258
    Camera #2 projections: 80% inliers (1999/2491) with MSE=0.128933
    Camera #3 projections: 78% inliers (2231/2855) with MSE=0.108087
    Camera #4 projections: 75% inliers (2513/3337) with MSE=0.138734
    Camera #5 projections: 77% inliers (2524/3258) with MSE=0.143122
    Camera #6 projections: 79% inliers (2828/3564) with MSE=0.129613
    Camera #7 projections: 82% inliers (2704/3292) with MSE=0.105793
    Camera #8 projections: 87% inliers (2757/3183) with MSE=0.132385
    Camera #9 projections: 93% inliers (2456/2639) with MSE=0.141355
[       OK ] SFM.ReconstructNViews (22415 ms)
[----------] 1 test from SFM (22415 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (22415 ms total)
[  PASSED  ] 1 test.

</pre>

</p></details>
