### PR TITLE
Task01 Андрей Петрухин СПбГУ

### DIFF
--- a/src/phg/sift/sift.cpp
+++ b/src/phg/sift/sift.cpp
@@ -19,21 +19,38 @@
 
 #define NOCTAVES                    3                    // число октав
 #define OCTAVE_NLAYERS              3                    // в [lowe04] это число промежуточных степеней размытия картинки в рамках одной октавы обозначается - s, т.е. s слоев в каждой октаве
+
+
+
 #define OCTAVE_GAUSSIAN_IMAGES      (OCTAVE_NLAYERS + 3)
 #define OCTAVE_DOG_IMAGES           (OCTAVE_NLAYERS + 2)
 #define INITIAL_IMG_SIGMA           0.75                 // предполагаемая степень размытия изначальной картинки
 #define INPUT_IMG_PRE_BLUR_SIGMA    1.0                  // сглаживание изначальной картинки
-   
+
 #define SUBPIXEL_FITTING_ENABLE      0    // такие тумблеры включающие/выключающие очередное улучшение алгоритма позволяют оценить какой вклад эта фича вносит в качество результата если в рамках уже готового алгоритма попробовать ее включить/выключить
+
+
 
 #define ORIENTATION_NHISTS           36   // число корзин при определении ориентации ключевой точки через гистограммы
 #define ORIENTATION_WINDOW_R         3    // минимальный радиус окна в рамках которого будет выбрана ориентиация (в пикселях), R=3 => 5x5 окно
+
+
+
 #define ORIENTATION_VOTES_PEAK_RATIO 0.80 // 0.8 => если гистограмма какого-то направления получила >= 80% от максимального чиссла голосов - она тоже победила
+
+
 
 #define DESCRIPTOR_SIZE            4 // 4x4 гистограммы декскриптора
 #define DESCRIPTOR_NBINS           8 // 8 корзин-направлений в каждой гистограмме дескриптора (4х4 гистограммы, каждая по 8 корзин, итого 4x4x8=128 значений в дескрипторе)
+
+
+
 #define DESCRIPTOR_SAMPLES_N       4 // 4x4 замера для каждой гистограммы дескриптора (всего гистограмм 4х4) итого 16х16 замеров
+
+
+
 #define DESCRIPTOR_SAMPLE_WINDOW_R 1.0 // минимальный радиус окна в рамках которого строится гистограмма из 8 корзин-направлений (т.е. для каждого из 16 элементов дескриптора), R=1 => 1x1 окно
+
 
 
 void phg::SIFT::detectAndCompute(const cv::Mat &originalImg, std::vector<cv::KeyPoint> &kps, cv::Mat &desc) {
@@ -45,9 +62,11 @@ void phg::SIFT::detectAndCompute(const cv::Mat &originalImg, std::vector<cv::Key
 
     cv::Mat img = originalImg.clone();
     // для удобства используем черно-белую картинку и работаем с вещественными числами (это еще и может улучшить точность)
-    if (originalImg.type() == CV_8UC1) { // greyscale image
+    if (originalImg.type() == CV_8UC1) {
+        // greyscale image
         img.convertTo(img, CV_32FC1, 1.0);
-    } else if (originalImg.type() == CV_8UC3) { // BGR image
+    } else if (originalImg.type() == CV_8UC3) {
+        // BGR image
         img.convertTo(img, CV_32FC3, 1.0);
         cv::cvtColor(img, img, cv::COLOR_BGR2GRAY);
     } else {
@@ -65,7 +84,8 @@ void phg::SIFT::detectAndCompute(const cv::Mat &originalImg, std::vector<cv::Key
     findLocalExtremasAndDescribe(gaussianPyramid, DoGPyramid, kps, desc);
 }
 
-void phg::SIFT::buildPyramids(const cv::Mat &imgOrg, std::vector<cv::Mat> &gaussianPyramid, std::vector<cv::Mat> &DoGPyramid) {
+void phg::SIFT::buildPyramids(const cv::Mat &imgOrg, std::vector<cv::Mat> &gaussianPyramid,
+                              std::vector<cv::Mat> &DoGPyramid) {
     gaussianPyramid.resize(NOCTAVES * OCTAVE_GAUSSIAN_IMAGES);
 
     const double k = pow(2.0, 1.0 / OCTAVE_NLAYERS); // [lowe04] k = 2^{1/s} а у нас s=OCTAVE_NLAYERS
@@ -74,82 +94,105 @@ void phg::SIFT::buildPyramids(const cv::Mat &imgOrg, std::vector<cv::Mat> &gauss
     for (size_t octave = 0; octave < NOCTAVES; ++octave) {
         if (octave == 0) {
             int layer = 0;
-            gaussianPyramid[octave * OCTAVE_GAUSSIAN_IMAGES + layer] = imgOrg.clone();
+            gaussianPyramid[octave * OCTAVE_GAUSSIAN_IMAGES] = imgOrg.clone();
         } else {
             int layer = 0;
             size_t prevOctave = octave - 1;
             // берем картинку с предыдущей октавы и уменьшаем ее в два раза без какого бы то ни было дополнительного размытия (сигмы должны совпадать)
-            // cv::Mat img = gaussianPyramid[ TODO ].clone();
+            // TODO 1
+            cv::Mat img = gaussianPyramid[prevOctave * OCTAVE_GAUSSIAN_IMAGES].clone();
             // тут есть очень важный момент, мы должны указать fx=0.5, fy=0.5 иначе при нечетном размере картинка будет не идеально 2 пикселя в один схлопываться - а слегка смещаться
-            // cv::resize(img, img, cv::Size( TODO , TODO ), 0.5, 0.5, cv::INTER_NEAREST);
-            // gaussianPyramid[octave * OCTAVE_GAUSSIAN_IMAGES + layer] = img;
+            // TODO 2
+            cv::resize(img, img, cv::Size(), 0.5, 0.5, cv::INTER_NEAREST);
+            gaussianPyramid[octave * OCTAVE_GAUSSIAN_IMAGES + layer] = img;
         }
 
-//        #pragma omp parallel for // TODO: если выполните TODO про "размытие из изначального слоя октавы" ниже - раскоментируйте это распараллеливание, ведь теперь слои считаются независимо (из самого первого), проверьте что результат на картинках не изменился
+#pragma omp parallel for
+
+
+
         for (ptrdiff_t layer = 1; layer < OCTAVE_GAUSSIAN_IMAGES; ++layer) {
             size_t prevLayer = layer - 1;
 
             // если есть два последовательных гауссовых размытия с sigma1 и sigma2, то результат будет с sigma12=sqrt(sigma1^2 + sigma2^2) => sigma2=sqrt(sigma12^2-sigma1^2)
-            double sigmaPrev = INITIAL_IMG_SIGMA * pow(2.0, octave) * pow(k, prevLayer); // sigma1  - сигма до которой дошла картинка на предыдущем слое
-            double sigmaCur  = INITIAL_IMG_SIGMA * pow(2.0, octave) * pow(k, layer);     // sigma12 - сигма до которой мы хотим дойти на текущем слое
-            double sigma = sqrt(sigmaCur*sigmaCur - sigmaPrev*sigmaPrev);                // sigma2  - сигма которую надо добавить чтобы довести sigma1 до sigma12
+            // double sigmaPrev = INITIAL_IMG_SIGMA * pow(2.0, octave) * pow(k, prevLayer); // sigma1  - сигма до которой дошла картинка на предыдущем слое
+            // double sigmaCur  = INITIAL_IMG_SIGMA * pow(2.0, octave) * pow(k, layer);     // sigma12 - сигма до которой мы хотим дойти на текущем слое
+            // double sigma = sqrt(sigmaCur*sigmaCur - sigmaPrev*sigmaPrev);                // sigma2  - сигма которую надо добавить чтобы довести sigma1 до sigma12
+
             // посмотрите внимательно на формулу выше и решите как по мнению этой формулы соотносится сигма у первого А-слоя i-ой октавы
             // и сигма у одного из последних слоев Б предыдущей (i-1)-ой октавы из которого этот слой А был получен?
             // а как чисто идейно должны бы соотноситься сигмы размытия у двух картинок если картинка А была получена из картинки Б простым уменьшением в 2 раза?
 
-            // TODO: переделайте это добавочное размытие с варианта "размываем предыдущий слой" на вариант "размываем самый первый слой октавы до степени размытия сигмы нашего текущего слоя"
-            // проверьте - картинки отладочного вывода выглядят один-в-один до/после? (посмотрите на них туда-сюда быстро мигая)
+            double sigmaOctave = INITIAL_IMG_SIGMA * pow(2.0, octave);
+            double sigmaCur = INITIAL_IMG_SIGMA * pow(2.0, octave) * pow(k, layer);
+            double sigma = sqrt(pow(sigmaCur, 2) - pow(sigmaOctave, 2));
 
-            cv::Mat imgLayer = gaussianPyramid[octave * OCTAVE_GAUSSIAN_IMAGES + prevLayer].clone();
+            // проверьте - картинки отладочного вывода выглядят один-в-один до/после? (посмотрите на них туда-сюда быстро мигая)
+            // cv::Mat imgLayer = gaussianPyramid[octave * OCTAVE_GAUSSIAN_IMAGES + prevLayer].clone();
+            // cv::GaussianBlur(imgLayer, imgLayer, automaticKernelSize, sigma, sigma);
+
+            cv::Mat imgOctave = gaussianPyramid[octave * OCTAVE_GAUSSIAN_IMAGES].clone();
             cv::Size automaticKernelSize = cv::Size(0, 0);
 
-            cv::GaussianBlur(imgLayer, imgLayer, automaticKernelSize, sigma, sigma);
+            cv::GaussianBlur(imgOctave, imgOctave, automaticKernelSize, sigma, sigma);
 
-            gaussianPyramid[octave * OCTAVE_GAUSSIAN_IMAGES + layer] = imgLayer;
+            if (DEBUG_ENABLE)
+                cv::imwrite(
+                    DEBUG_PATH + std::to_string(octave) + "_" + std::to_string(layer) + "_oct.png", imgOctave);
+            gaussianPyramid[octave * OCTAVE_GAUSSIAN_IMAGES + layer] = imgOctave;
         }
     }
 
     for (size_t octave = 0; octave < NOCTAVES; ++octave) {
         for (size_t layer = 0; layer < OCTAVE_GAUSSIAN_IMAGES; ++layer) {
             double sigmaCur = INITIAL_IMG_SIGMA * pow(2.0, octave) * pow(k, layer);
-            if (DEBUG_ENABLE) cv::imwrite(DEBUG_PATH + "pyramid/o" + to_string(octave) + "_l" + to_string(layer) + "_s" + to_string(sigmaCur) + ".png", gaussianPyramid[octave * OCTAVE_GAUSSIAN_IMAGES + layer]);
+            if (DEBUG_ENABLE)
+                cv::imwrite(
+                    DEBUG_PATH + "pyramid/o" + to_string(octave) + "_l" + to_string(layer) + "_s" + to_string(sigmaCur)
+                    +
+                    ".png", gaussianPyramid[octave * OCTAVE_GAUSSIAN_IMAGES + layer]);
             // TODO: какие ожидания от картинок можно придумать? т.е. как дополнительно проверить что работает разумно?
-            // спойлер: подуймайте с чем должна визуально совпадать картинка из октавы? может быть с какой-то из картинок с предыдущей октавы? с какой? как их визуально сверить ведь они разного размера? 
+            // спойлер: подуймайте с чем должна визуально совпадать картинка из октавы? может быть с какой-то из картинок с предыдущей октавы? с какой? как их визуально сверить ведь они разного размера?
         }
     }
 
     DoGPyramid.resize(NOCTAVES * OCTAVE_DOG_IMAGES);
 
     // строим пирамиду разниц гауссиан слоев (Difference of Gaussian, DoG), т.к. вычитать надо из слоя слой в рамках одной и той же октавы - то есть приятный параллелизм на уровне октав
-    #pragma omp parallel for
+#pragma omp parallel for
     for (ptrdiff_t octave = 0; octave < NOCTAVES; ++octave) {
         for (size_t layer = 1; layer < OCTAVE_GAUSSIAN_IMAGES; ++layer) {
             int prevLayer = layer - 1;
             cv::Mat imgPrevGaussian = gaussianPyramid[octave * OCTAVE_GAUSSIAN_IMAGES + prevLayer];
-            cv::Mat imgCurGaussian  = gaussianPyramid[octave * OCTAVE_GAUSSIAN_IMAGES + layer];
+            cv::Mat imgCurGaussian = gaussianPyramid[octave * OCTAVE_GAUSSIAN_IMAGES + layer];
 
-            cv::Mat imgCurDoG = imgCurGaussian.clone();
+            // cv::Mat imgCurDoG = imgCurGaussian.clone();
+            cv::Mat diff = imgCurGaussian - imgPrevGaussian;
             // обратите внимание что т.к. пиксели картинки из одного ряда лежат в памяти подряд, поэтому если вложенный цикл бежит подряд по одному и тому же ряду
             // то код работает быстрее т.к. он будет более cache-friendly, можете сравнить оценить ускорение добавив замер времени построения пирамиды: timer t; double time_s = t.elapsed();
-            for (size_t j = 0; j < imgCurDoG.rows; ++j) {
-                for (size_t i = 0; i < imgCurDoG.cols; ++i) {
-                    imgCurDoG.at<float>(j, i) = imgCurGaussian.at<float>(j, i) - imgPrevGaussian.at<float>(j, i);
-                }
-            }
+            // for (size_t j = 0; j < imgCurDoG.rows; ++j) {
+            //     for (size_t i = 0; i < imgCurDoG.cols; ++i) {
+            //         imgCurDoG.at<float>(j, i) = imgCurGaussian.at<float>(j, i) - imgPrevGaussian.at<float>(j, i);
+            //     }
+            // }
             int dogLayer = layer - 1;
-            DoGPyramid[octave * OCTAVE_DOG_IMAGES + dogLayer] = imgCurDoG;
+            // DoGPyramid[octave * OCTAVE_DOG_IMAGES + dogLayer] = imgCurDoG;
+            DoGPyramid[octave * OCTAVE_DOG_IMAGES + dogLayer] = diff;
         }
     }
 
     // нам нужны padding-картинки по краям октавы чтобы извлекать экстремумы, но в статье предлагается не s+2 а s+3: [lowe04] We must produce s + 3 images in the stack of blurred images for each octave, so that final extrema detection covers a complete octave
-    // TODO: почему OCTAVE_GAUSSIAN_IMAGES=(OCTAVE_NLAYERS + 3) а не например (OCTAVE_NLAYERS + 2)?
 
     for (size_t octave = 0; octave < NOCTAVES; ++octave) {
         for (size_t layer = 0; layer < OCTAVE_DOG_IMAGES; ++layer) {
             double sigmaCur = INITIAL_IMG_SIGMA * pow(2.0, octave) * pow(k, layer);
-            if (DEBUG_ENABLE) cv::imwrite(DEBUG_PATH + "pyramidDoG/o" + to_string(octave) + "_l" + to_string(layer) + "_s" + to_string(sigmaCur) + ".png", DoGPyramid[octave * OCTAVE_DOG_IMAGES + layer]);
+            if (DEBUG_ENABLE)
+                cv::imwrite(
+                    DEBUG_PATH + "pyramidDoG/o" + to_string(octave) + "_l" + to_string(layer) + "_s" + to_string(
+                        sigmaCur) +
+                    ".png", DoGPyramid[octave * OCTAVE_DOG_IMAGES + layer]);
             // TODO: какие ожидания от картинок можно придумать? т.е. как дополнительно проверить что работает разумно?
-            // спойлер: подуймайте с чем должна визуально совпадать картинка из октавы DoG? может быть с какой-то из картинок с предыдущей октавы? с какой? как их визуально сверить ведь они разного размера? 
+            // спойлер: подуймайте с чем должна визуально совпадать картинка из октавы DoG? может быть с какой-то из картинок с предыдущей октавы? с какой? как их визуально сверить ведь они разного размера?
         }
     }
 }
@@ -168,73 +211,82 @@ namespace {
 
         // (3)-2*(2): 2*a-y0=y2-2*y1; a=(y2-2*y1+y0)/2
         // (2):       b=y1-y0-a
-        float a = (x2-2.0f*x1+x0) / 2.0f;
+        float a = (x2 - 2.0f * x1 + x0) / 2.0f;
         float b = x1 - x0 - a;
         // extremum is at -b/(2*a), but our system coordinate start (i) is at 1, so minus 1
-        float shift = - b / (2.0f * a) - 1.0f;
+        float shift = -b / (2.0f * a) - 1.0f;
         return shift;
     }
 }
 
-void phg::SIFT::findLocalExtremasAndDescribe(const std::vector<cv::Mat> &gaussianPyramid, const std::vector<cv::Mat> &DoGPyramid,
+void phg::SIFT::findLocalExtremasAndDescribe(const std::vector<cv::Mat> &gaussianPyramid,
+                                             const std::vector<cv::Mat> &DoGPyramid,
                                              std::vector<cv::KeyPoint> &keyPoints, cv::Mat &desc) {
-    std::vector<std::vector<float>> pointsDesc;
+    std::vector<std::vector<float> > pointsDesc;
 
     // 3.1 Local extrema detection
-    #pragma omp parallel // запустили каждый вычислительный поток процессора
+#pragma omp parallel // запустили каждый вычислительный поток процессора
     {
         // каждый поток будет складировать свои точки в свой личный вектор (чтобы не было гонок и не были нужны точки синхронизации)
         std::vector<cv::KeyPoint> thread_points;
-        std::vector<std::vector<float>> thread_descriptors;
+        std::vector<std::vector<float> > thread_descriptors;
 
         for (size_t octave = 0; octave < NOCTAVES; ++octave) {
             double octave_downscale = pow(2.0, octave);
             for (size_t layer = 1; layer + 1 < OCTAVE_DOG_IMAGES; ++layer) {
                 const cv::Mat prev = DoGPyramid[octave * OCTAVE_DOG_IMAGES + layer - 1];
-                const cv::Mat cur  = DoGPyramid[octave * OCTAVE_DOG_IMAGES + layer];
+                const cv::Mat cur = DoGPyramid[octave * OCTAVE_DOG_IMAGES + layer];
                 const cv::Mat next = DoGPyramid[octave * OCTAVE_DOG_IMAGES + layer + 1];
                 const cv::Mat DoGs[3] = {prev, cur, next};
 
-                // теперь каждый поток обработает свой кусок картинки 
-                #pragma omp for
+                // теперь каждый поток обработает свой кусок картинки
+#pragma omp for
                 for (ptrdiff_t j = 1; j < cur.rows - 1; ++j) {
-                    for (ptrdiff_t i = 1; i + 1 < cur.cols; ++i) {
+                    for (ptrdiff_t i = 1; i < cur.cols - 1; ++i) {
                         bool is_max = true;
                         bool is_min = true;
                         float center = DoGs[1].at<float>(j, i);
                         for (int dz = -1; dz <= 1 && (is_min || is_max); ++dz) {
-                        for (int dy = -1; dy <= 1 && (is_min || is_max); ++dy) {
-                        for (int dx = -1; dx <= 1 && (is_min || is_max); ++dx) {
-                            // TODO проверить является ли наш центр все еще экстремум по сравнению с соседом DoGs[1+dz].at<float>(j+dy, i+dx) ? (не забудьте учесть что один из соседов - это мы сами)
-                        }
-                        }
+                            for (int dy = -1; dy <= 1 && (is_min || is_max); ++dy) {
+                                for (int dx = -1; dx <= 1 && (is_min || is_max); ++dx) {
+                                    if (dz == 0 && dy == 0 && dx == 0) continue;
+                                    if (DoGs[1 + dz].at<float>(j + dy, i + dx) >= center) {
+                                        is_max = false;
+                                    }
+                                    if (DoGs[1 + dz].at<float>(j + dy, i + dx) <= center) {
+                                        is_min = false;
+                                    }
+                                }
+                            }
                         }
                         bool is_extremum = (is_min || is_max);
 
                         if (!is_extremum)
-                            continue; // очередной элемент cascade filtering, если не экстремум - сразу заканчиваем обработку этого пикселя
+                            continue;
+                        // очередной элемент cascade filtering, если не экстремум - сразу заканчиваем обработку этого пикселя
 
                         // 4 Accurate keypoint localization
                         cv::KeyPoint kp;
                         float dx = 0.0f;
                         float dy = 0.0f;
                         float dvalue = 0.0f;
-                        // TODO сделать субпиксельное уточнение (хотя бы через параболу-фиттинг независимо по оси X и оси Y, но лучше через честный ряд Тейлора, матрицу Гессе и итеративное смещение если экстремум оказался в соседнем пикселе)
 #if SUBPIXEL_FITTING_ENABLE // такие тумблеры включающие/выключающие очередное улучшение алгоритма позволяют оценить какой вклад эта фича вносит в качество результата если в рамках уже готового алгоритма попробовать ее включить/выключить
+
+
                         {
-                            // TODO
+                            // TODO сделать субпиксельное уточнение (хотя бы через параболу-фиттинг независимо по оси X и оси Y, но лучше через честный ряд Тейлора, матрицу Гессе и итеративное смещение если экстремум оказался в соседнем пикселе)
                         }
 #endif
-                        // TODO сделать фильтрацию слабых точек по слабому контрасту
                         float contrast = center + dvalue;
-                        if (contrast < contrast_threshold / OCTAVE_NLAYERS) // TODO почему порог контрастности должен уменьшаться при увеличении числа слоев в октаве?
+                        if (contrast < contrast_threshold / OCTAVE_NLAYERS)
                             continue;
 
-                        kp.pt = cv::Point2f((i + 0.5 + dx) * octave_downscale, (j + 0.5 + dy) * octave_downscale);
+                        kp.pt = cv::Point2f((0.5 + i + dx) * octave_downscale, (j + 0.5 + dy) * octave_downscale);
 
                         kp.response = fabs(contrast);
 
-                        const double k = pow(2.0, 1.0 / OCTAVE_NLAYERS); // [lowe04] k = 2^{1/s} а у нас s=OCTAVE_NLAYERS
+                        const double k = pow(2.0, 1.0 / OCTAVE_NLAYERS);
+                        // [lowe04] k = 2^{1/s} а у нас s=OCTAVE_NLAYERS
                         double sigmaCur = INITIAL_IMG_SIGMA * pow(2.0, octave) * pow(k, layer);
                         kp.size = 2.0 * sigmaCur * 5.0;
 
@@ -250,11 +302,12 @@ void phg::SIFT::findLocalExtremasAndDescribe(const std::vector<cv::Mat> &gaussia
                             float prevValue = votes[(bin + ORIENTATION_NHISTS - 1) % ORIENTATION_NHISTS];
                             float value = votes[bin];
                             float nextValue = votes[(bin + 1) % ORIENTATION_NHISTS];
-                            if (value > prevValue && value > nextValue && votes[bin] > biggestVote * ORIENTATION_VOTES_PEAK_RATIO) {
-                                // TODO добавьте уточнение угла наклона - может помочь определенная выше функция parabolaFitting(float x0, float x1, float x2)
-                                kp.angle = (bin + 0.5) * (360.0 / ORIENTATION_NHISTS);
+                            if (value > prevValue && value > nextValue && votes[bin] > biggestVote *
+                                ORIENTATION_VOTES_PEAK_RATIO) {
+                                auto angleRefinement = parabolaFitting(prevValue, value, nextValue);
+                                kp.angle = (bin + 0.5) * (360.0 / ORIENTATION_NHISTS) + angleRefinement;
                                 rassert(kp.angle >= 0.0 && kp.angle <= 360.0, 123512412412);
-                                
+
                                 std::vector<float> descriptor;
                                 double descrSampleRadius = (DESCRIPTOR_SAMPLE_WINDOW_R * (1.0 + k * (layer - 1)));
                                 if (!buildDescriptor(img, kp.pt.x, kp.pt.y, descrSampleRadius, kp.angle, descriptor))
@@ -270,7 +323,7 @@ void phg::SIFT::findLocalExtremasAndDescribe(const std::vector<cv::Mat> &gaussia
         }
 
         // в критической секции объединяем все массивы детектированных точек
-        #pragma omp critical
+#pragma omp critical
         {
             keyPoints.insert(keyPoints.end(), thread_points.begin(), thread_points.end());
             pointsDesc.insert(pointsDesc.end(), thread_descriptors.begin(), thread_descriptors.end());
@@ -293,29 +346,26 @@ bool phg::SIFT::buildLocalOrientationHists(const cv::Mat &img, size_t i, size_t 
     votes.resize(ORIENTATION_NHISTS, 0.0f);
     biggestVote = 0.0;
 
-    if (i-1 < radius - 1 || i+1 + radius - 1 >= img.cols || j-1 < radius - 1 || j+1 + radius - 1 >= img.rows)
+    if (i - 1 < radius - 1 || i + 1 + radius - 1 >= img.cols || j - 1 < radius - 1 || j + 1 + radius - 1 >= img.rows)
         return false;
 
     float sum[ORIENTATION_NHISTS] = {0.0f};
 
     for (size_t y = j - radius + 1; y < j + radius; ++y) {
         for (size_t x = i - radius + 1; x < i + radius; ++x) {
-            // m(x, y)=(L(x + 1, y) − L(x − 1, y))^2 + (L(x, y + 1) − L(x, y − 1))^2
-            // double magnitude = TODO
+            auto dx = img.at<float>(y, x + 1) - img.at<float>(y, x - 1);
+            auto dy = img.at<float>(y + 1, x) - img.at<float>(y - 1, x);
 
-            // orientation == theta
-            // atan( (L(x, y + 1) − L(x, y − 1)) / (L(x + 1, y) − L(x − 1, y)) )
-            // double orientation = TODO // подсказка - используйте atan2(dy, dx)
-//            orientation = orientation * 180.0 / M_PI;
-//            orientation = (orientation + 90.0);
-//            if (orientation <  0.0)   orientation += 360.0;
-//            if (orientation >= 360.0) orientation -= 360.0;
-//            rassert(orientation >= 0.0 && orientation < 360.0, 5361615612);
-//            static_assert(360 % ORIENTATION_NHISTS == 0, "Inappropriate bins number!");
-//            size_t bin = TODO
-//            rassert(bin < ORIENTATION_NHISTS, 361236315613);
-//            sum[bin] += magnitude;
-            // TODO может быть сгладить получившиеся гистограммы улучшит результат? 
+            double magnitude = std::hypot(dx, dy);
+            double orientation = atan2(dy, dx) / M_PI * 180.0 + 90.0;
+            while (orientation < 0.0) orientation += 360.0;
+            while (orientation >= 360.0) orientation -= 360.0;
+            rassert(orientation >= 0.0 && orientation < 360.0, 5361615612);
+            static_assert(360 % ORIENTATION_NHISTS == 0, "Inappropriate bins number!");
+            auto bin = static_cast<size_t>(orientation / 360.0) * ORIENTATION_NHISTS;
+            rassert(bin < ORIENTATION_NHISTS, 361236315613);
+            sum[bin] += magnitude;
+            // TODO может быть сгладить получившиеся гистограммы улучшит результат?
         }
     }
 
@@ -334,50 +384,62 @@ bool phg::SIFT::buildDescriptor(const cv::Mat &img, float px, float py, double d
     const double smpW = 2.0 * descrSampleRadius - 1.0;
 
     descriptor.resize(DESCRIPTOR_SIZE * DESCRIPTOR_SIZE * DESCRIPTOR_NBINS, 0.0f);
-    for (int hstj = 0; hstj < DESCRIPTOR_SIZE; ++hstj) { // перебираем строку в решетке гистограмм
-        for (int hsti = 0; hsti < DESCRIPTOR_SIZE; ++hsti) { // перебираем колонку в решетке гистограмм
+    for (int hstj = 0; hstj < DESCRIPTOR_SIZE; ++hstj) {
+        // перебираем строку в решетке гистограмм
+        for (int hsti = 0; hsti < DESCRIPTOR_SIZE; ++hsti) {
+            // перебираем колонку в решетке гистограмм
 
             float sum[DESCRIPTOR_NBINS] = {0.0f};
 
-            for (int smpj = 0; smpj < DESCRIPTOR_SAMPLES_N; ++smpj) { // перебираем строчку замера для текущей гистограммы
-                for (int smpi = 0; smpi < DESCRIPTOR_SAMPLES_N; ++smpi) { // перебираем столбик очередного замера для текущей гистограммы
-                    for (int smpy = 0; smpy < smpW; ++smpy) { // перебираем ряд пикселей текущего замера
-                        for (int smpx = 0; smpx < smpW; ++smpx) { // перебираем столбик пикселей текущего замера
-//                            cv::Point2f shift(((-DESCRIPTOR_SIZE/2.0 + hsti) * DESCRIPTOR_SAMPLES_N + smpi) * smpW, TODO);
-//                            std::vector<cv::Point2f> shiftInVector(1, shift);
-//                            cv::transform(shiftInVector, shiftInVector, relativeShiftRotation); // преобразуем относительный сдвиг с учетом ориентации ключевой точки
-//                            shift = shiftInVector[0];
+            for (int smpj = 0; smpj < DESCRIPTOR_SAMPLES_N; ++smpj) {
+                // перебираем строчку замера для текущей гистограммы
+                for (int smpi = 0; smpi < DESCRIPTOR_SAMPLES_N; ++smpi) {
+                    // перебираем столбик очередного замера для текущей гистограммы
+                    for (int smpy = 0; smpy < smpW; ++smpy) {
+                        // перебираем ряд пикселей текущего замера
+                        for (int smpx = 0; smpx < smpW; ++smpx) {
+                            // перебираем столбик пикселей текущего замера
+                            cv::Point2f shift(((-DESCRIPTOR_SIZE / 2.0 + hsti) * DESCRIPTOR_SAMPLES_N + smpi) * smpW,
+                                              ((-DESCRIPTOR_SIZE / 2.0 + hstj) * DESCRIPTOR_SAMPLES_N + smpj) * smpW);
+                            std::vector<cv::Point2f> shiftInVector(1, shift);
+                            cv::transform(shiftInVector, shiftInVector, relativeShiftRotation);
+                            // преобразуем относительный сдвиг с учетом ориентации ключевой точки
+                            shift = shiftInVector[0];
+                            int x = (int) (px + shift.x);
+                            int y = (int) (py + shift.y);
 
-//                            int x = (int) (px + shift.x);
-//                            int y = TODO;
+                            if (y - 1 < 0 || y + 1 >= img.rows || x - 1 < 0 || x + 1 >= img.cols)
+                                return false;
 
-//                            if (y - 1 < 0 || y + 1 > img.rows || x - 1 < 0 || x + 1 > img.cols)
-//                                return false;
+                            auto dx = img.at<float>(y, x + 1) - img.at<float>(y, x - 1);
+                            auto dy = img.at<float>(y + 1, x) - img.at<float>(y - 1, x);
+                            float magnitude = std::hypot(dx, dy);
+                            float orientation = atan2(dy, dx) * (180.0 / M_PI) + 90.0 - angle;
+                            while (orientation < 0.0) orientation += 360.0;
+                            while (orientation >= 360.0) orientation -= 360.0;
 
-//                            double magnitude = TODO
+                            // TODO за счет чего этот вклад будет сравниваться с этим же вкладом даже если эта картинка будет повернута? что нужно сделать с ориентацией каждого градиента из окрестности этой ключевой точки?
 
-//                            double orientation = atan2(TODO);
-//                            orientation = orientation * 180.0 / M_PI;
-//                            orientation = (orientation + 90.0);
-//                            if (orientation <  0.0)   orientation += 360.0;
-//                            if (orientation >= 360.0) orientation -= 360.0;
-
-                              // TODO за счет чего этот вклад будет сравниваться с этим же вкладом даже если эта картинка будет повернута? что нужно сделать с ориентацией каждого градиента из окрестности этой ключевой точки?
-
-//                            rassert(orientation >= 0.0 && orientation < 360.0, 3515215125412);
+                            rassert(orientation >= 0.0 && orientation < 360.0, dy);
                             static_assert(360 % DESCRIPTOR_NBINS == 0, "Inappropriate bins number!");
-//                            size_t bin = TODO;
-//                            rassert(bin < DESCRIPTOR_NBINS, 361236315613);
-//                            sum[bin] += magnitude;
+                            auto bin = static_cast<size_t>(orientation / 360.0) * ORIENTATION_NHISTS;
+                            rassert(bin < DESCRIPTOR_NBINS, 361236315613);
+                            sum[bin] += magnitude;
                             // TODO хорошая идея добавить трилинейную интерполяцию как предложено в статье, или хотя бы сэмулировать ее - сгладить получившиеся гистограммы
                         }
                     }
                 }
             }
-
-            // TODO нормализовать наш вектор дескриптор (подсказка: посчитать его длину и поделить каждую компоненту на эту длину)
-
-            float *votes = &(descriptor[(hstj * DESCRIPTOR_SIZE + hsti) * DESCRIPTOR_NBINS]); // нашли где будут лежать корзины нашей гистограммы
+            float length = 0;
+            for (float i: sum) {
+                length += i * i;
+            }
+            length = sqrtf(length);
+            for (float &i: sum) {
+                i /= length;
+            }
+            float *votes = &(descriptor[(hstj * DESCRIPTOR_SIZE + hsti) * DESCRIPTOR_NBINS]);
+            // нашли где будут лежать корзины нашей гистограммы
             for (int bin = 0; bin < DESCRIPTOR_NBINS; ++bin) {
                 votes[bin] = sum[bin];
             }

--- a/src/phg/sift/sift.h
+++ b/src/phg/sift/sift.h
@@ -6,20 +6,22 @@
 
 
 namespace phg {
-
     class SIFT {
     public:
         // Можете добавить дополнительных параметров со значениями по умолчанию в конструктор если хотите
-        SIFT(double contrast_threshold = 0.5) : contrast_threshold(contrast_threshold) {}
+        SIFT(double contrast_threshold = 0.5) : contrast_threshold(contrast_threshold) {
+        }
 
         // Сигнатуру этого метода менять нельзя
         void detectAndCompute(const cv::Mat &originalImg, std::vector<cv::KeyPoint> &kps, cv::Mat &desc);
 
     protected: // Можете менять внутренние детали реализации включая разбиение на эти методы (это просто набросок):
 
-        void buildPyramids(const cv::Mat &imgOrg, std::vector<cv::Mat> &gaussianPyramid, std::vector<cv::Mat> &DoGPyramid);
+        void buildPyramids(const cv::Mat &imgOrg, std::vector<cv::Mat> &gaussianPyramid,
+                           std::vector<cv::Mat> &DoGPyramid);
 
-        void findLocalExtremasAndDescribe(const std::vector<cv::Mat> &gaussianPyramid, const std::vector<cv::Mat> &DoGPyramid,
+        void findLocalExtremasAndDescribe(const std::vector<cv::Mat> &gaussianPyramid,
+                                          const std::vector<cv::Mat> &DoGPyramid,
                                           std::vector<cv::KeyPoint> &keyPoints, cv::Mat &desc);
 
         bool buildLocalOrientationHists(const cv::Mat &img, size_t i, size_t j, size_t radius,
@@ -30,5 +32,4 @@ namespace phg {
 
         double contrast_threshold;
     };
-
 }


### PR DESCRIPTION
# Перечислите идеи и коротко обозначьте мысли которые у вас возникали по мере выполнения задания, в частности попробуйте ответить на вопросы:

1) Почему SIFT менее точно угадывает средний угол отклонения? изменяется ли ситуация если выкрутить параметр ORIENTATION_VOTES_PEAK_RATIO=0.999? почему?

Кажется, это связано с тем, что мы вычисляем градиент по 5 точкам, а не по какой-то окрестности. При повороте мы почти наверное не возьмем те же 5 точек, например. Если устремить параметр к 1, для ключевой точки будет появляться меньше дупликатов - это долно уменьшит число мэтчей, но увеличить их точность, а проблему не решит - мы всё ещё будем вычислять градиенты по потенциально разным точкам

2) Как надежно замерить во сколько раз распараллеливание через OpenMP ускоряет ваш вариант SIFT? Попробуйте сделать это на вашем компьютере, какое ускорение относительно однопоточной версии оказалось? Сколько у вашего процессора ядер и сколько потоков?

"По-честному" нужно бенчмаркать каждый фрагмент кода, не совсем "по-честному" добавил флаги для включения\выключения дампов и распараллеливания, ускорение примерно вдвое. У моего процессора 8 ядер и по 2 потока на ядро

3) Правда ли можно строить каждый слой в Gaussian пирамиде из самого первого слоя этой октавы? Или нужно обязательно делать так как предложено в статье - дополняя размытие предыдущего слоя этой октавы? Совпадают ли пирамиды визуально?

Это должно быть верно из свойства сверток с ядром гаусса. Визуально пирамиды совпадают

4) Какие ожидания от картинок в Gaussian пирамиде можно придумать? Как проверить что работает корректно? С какой другой картинкой предыдущей октавы должна визуально совпадать конкретная картинка конкретной октавы? Как их визуально сравнить, ведь они разного размера?

Для s+1 картинки октавы будем иметь `sigma = img_sigma * 2^octave`, а это похоже на sigma для первой картинки следующей октавы

5) Почему в октаве Gaussian пирамиды s+3 картинки а не s+2 например?

Хотим искать экстремумы по s картинкам в DoG октавы, значит в DoG должно быть s+2 картинки, тогда в Gaussian - s+3

6) Какие ожидания от картинок в DoG пирамиде можно придумать?

Они должны быть почти черными, т.к. разница частот в точке должна примерно совпадать. Так же должны быть видны белые контуры объектов, по размеру близкие к размеру ядра

7) Почему порог контрастности должен уменьшаться при увеличении числа слоев в октаве?

Потому что гауссианы будут меньше отличаться 

8) Какая строка ответственна за определение сигмы (или что почти то же самое - радиуса) которая задает окрестность по которой определяется ориентация ключевой точки?

`int oriRadius = (int) (ORIENTATION_WINDOW_R * (1.0 + k * (layer - 1)));`

9) За какой строки вашего кода дескриптор инвариантен к повороту картинки?

`float orientation = atan2(dy, dx) * (180.0 / M_PI) + 90.0 - angle;`

buildDescriptor 418

// Создайте PR.
// Дождитесь отработки Github Actions CI, после чего нажмите на зеленую галочку -> Details -> test_sift -> скопируйте весь лог тестирования.
// Откройте PR на редактирование (сверху справа три точки->Edit) и добавьте сюда скопированный лог тестирования внутри тега <pre> для сохранения форматирования и под спойлером для компактности и удобства:

<details><summary>Github Actions CI</summary><p>

<pre>
$ ./build/test_sift
Running main() from /home/runner/work/PhotogrammetryTasks2023/PhotogrammetryTasks2023/libs/3rdparty/libgtest/googletest/src/gtest_main.cc
[==========] Running 22 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 22 tests from SIFT
[ RUN      ] SIFT.MovedTheSameImage
[ORB_OCV] Points detected: 500 -> 500 (in 0.021269 sec)
...
[       OK ] SIFT.HerzJesu19RotateM40 (7730 ms)
[----------] 22 tests from SIFT (12918 ms total)
[----------] Global test environment tear-down
[==========] 22 tests from 1 test suite ran. (12918 ms total)
[  PASSED  ] 22 tests.
</pre>

</p></details>